### PR TITLE
Improved error logging

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OMJulia"
 uuid = "0f4fe800-344e-11e9-2949-fb537ad918e1"
 authors = ["Martin Sjölund <martin.sjolund@liu.se>", "Arunkumar Palanisamy <arunkumar.palanisamy@liu.se>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
@@ -11,9 +11,12 @@ LightXML = "9c8b4983-aa76-5018-a973-4c85ecc9e179"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ZMQ = "c2297ded-f4af-51ae-bb23-16f91089e4e1"
 
+[compat]
+ZMQ = "1"
+julia = "1"
+
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[compat]
-julia = "1"
-ZMQ = "1"
+[targets]
+test = ["Test"]

--- a/src/OMJulia.jl
+++ b/src/OMJulia.jl
@@ -115,8 +115,8 @@ mutable struct OMCSession
             args4 = randstring(10)
         end
         if (Base.Sys.iswindows())
-            # @assert omc == nothing "A Custom omc path for windows is not supported"
-            if (omc != nothing)
+            # @assert omc === nothing "A Custom omc path for windows is not supported"
+            if (omc !== nothing)
                 ompath = replace(omc, r"[/\\]+" => "/")
                 dirpath = dirname(dirname(omc))
                 ## create a omc process with OPENMODELICAHOME set to custom directory
@@ -144,13 +144,13 @@ mutable struct OMCSession
             if (Base.Sys.isapple())
                 # add omc to path if not exist
                 ENV["PATH"] = ENV["PATH"] * "/opt/openmodelica/bin"
-                if (omc != nothing)
+                if (omc !== nothing)
                     this.omcprocess = open(pipeline(`$omc $args2 $args3$args4`))
                 else
                     this.omcprocess = open(pipeline(`omc $args2 $args3$args4`))
                 end
             else
-                if (omc != nothing)
+                if (omc !== nothing)
                     this.omcprocess = open(pipeline(`$omc $args2 $args3$args4`))
                 else
                     this.omcprocess = open(pipeline(`omc $args2 $args3$args4`))
@@ -199,7 +199,7 @@ ModelicaSystem(obj,"BouncingBall.mo","BouncingBall",["Modelica", "SystemDynamics
 """
 function ModelicaSystem(omc, filename, modelname, library=nothing; commandLineOptions=nothing, variableFilter=nothing)
     ## check for commandLineOptions
-    if (commandLineOptions != nothing)
+    if (commandLineOptions !== nothing)
         exp = join(["setCommandLineOptions(","","\"",commandLineOptions,"\"" ,")"])
         cmdexp = sendExpression(omc, exp)
         if (!cmdexp)
@@ -225,7 +225,7 @@ function ModelicaSystem(omc, filename, modelname, library=nothing; commandLineOp
     end
     sendExpression(omc, "cd(\"" * omc.tempdir * "\")")
     # load Libraries provided by users
-    if (library != nothing)
+    if (library !== nothing)
         if (isa(library, String))
             loadLibraryHelper(omc, library)
         # allow users to provide library version eg.(Modelica, "3.2.3")
@@ -265,7 +265,7 @@ function loadLibraryHelper(omc, libname, version=nothing)
             return println(sendExpression(omc, "getErrorString()"))
         end
     else
-        if version == nothing
+        if version === nothing
             libname = join(["loadModel(", libname, ")"])
         else
             libname = join(["loadModel(", libname, ", ", "{", "\"", version, "\"", "}", ")"])
@@ -282,12 +282,12 @@ end
 Standard buildModel API which builds the modelica model
 """
 function buildModel(omc; variableFilter=nothing)
-    if (variableFilter != nothing)
+    if (variableFilter !== nothing)
         omc.variableFilter = variableFilter
     end
     # println(omc.variableFilter)
 
-    if (omc.variableFilter != nothing)
+    if (omc.variableFilter !== nothing)
         varFilter = join(["variableFilter=", "\"", omc.variableFilter, "\""])
     else
         varFilter = join(["variableFilter=\"", ".*" ,"\""])
@@ -340,7 +340,7 @@ function xmlparse(omc)
                         subchild = child_elements(r)
                         for s in subchild
                             value = attribute(s, "start")
-                            if (value != nothing)
+                            if (value !== nothing)
                                 scalar["value"] = value
                             else
                                 scalar["value"] = "None"
@@ -401,7 +401,7 @@ standard getXXX() API
 function which return list of all variables parsed from xml file
 """
 function getQuantities(omc, name=nothing)
-    if (name == nothing)
+    if (name === nothing)
         return omc.quantitieslist
     elseif (isa(name, String))
         return [x for x in omc.quantitieslist if x["name"] == name]
@@ -455,7 +455,7 @@ standard getXXX() API
 function which returns the parameter variables parsed from xmlfile
 """
 function getParameters(omc, name=nothing)
-    if (name == nothing)
+    if (name === nothing)
         return omc.parameterlist
     elseif (isa(name, String))
         return get(omc.parameterlist, name, 0)
@@ -469,7 +469,7 @@ standard getXXX() API
 function which returns the SimulationOption variables parsed from xmlfile
 """
 function getSimulationOptions(omc, name=nothing)
-    if (name == nothing)
+    if (name === nothing)
         return omc.simulateOptions
     elseif (isa(name, String))
         return get(omc.simulateOptions, name, 0)
@@ -484,7 +484,7 @@ function which returns the continuous variables parsed from xmlfile
 """
 function getContinuous(omc, name=nothing)
     if (omc.simulationFlag == false)
-        if (name == nothing)
+        if (name === nothing)
             return omc.continuouslist
         elseif (isa(name, String))
             return get(omc.continuouslist, name, 0)
@@ -493,7 +493,7 @@ function getContinuous(omc, name=nothing)
         end
     end
     if (omc.simulationFlag == true)
-        if (name == nothing)
+        if (name === nothing)
             for name in keys(omc.continuouslist)
                 ## failing for variables with $ sign
                 ## println(name)
@@ -537,7 +537,7 @@ standard getXXX() API
 function which returns the input variables parsed from xmlfile
 """
 function getInputs(omc, name=nothing)
-    if (name == nothing)
+    if (name === nothing)
         return omc.inputlist
     elseif (isa(name, String))
         return get(omc.inputlist, name, 0)
@@ -552,7 +552,7 @@ function which returns the output variables parsed from xmlfile
 """
 function getOutputs(omc, name=nothing)
     if (omc.simulationFlag == false)
-        if (name == nothing)
+        if (name === nothing)
             return omc.outputlist
         elseif (isa(name, String))
             return get(omc.outputlist, name, 0)
@@ -561,7 +561,7 @@ function getOutputs(omc, name=nothing)
         end
     end
     if (omc.simulationFlag == true)
-        if (name == nothing)
+        if (name === nothing)
             for name in keys(omc.outputlist)
                 value = getSolutions(omc, name)
                 value1 = value[1]
@@ -604,7 +604,7 @@ second argument resultfile and third argument simflags are optional, An example 
 """
 function simulate(omc; resultfile=nothing, simflags=nothing, verbose=true)
     # println(this.xmlfile)
-    if (resultfile == nothing)
+    if (resultfile === nothing)
         r = ""
         omc.resultfile = replace(joinpath(omc.tempdir, join([omc.modelname,"_res.mat"])), r"[/\\]+" => "/")
     else
@@ -612,7 +612,7 @@ function simulate(omc; resultfile=nothing, simflags=nothing, verbose=true)
         omc.resultfile = replace(joinpath(omc.tempdir, resultfile), r"[/\\]+" => "/")
     end
 
-    if (simflags == nothing)
+    if (simflags === nothing)
         simflags = ""
     end
 
@@ -770,7 +770,7 @@ Function which reads the result file and return the simulation results to user
 which can be used for plotting or further anlaysis
 """
 function getSolutions(omc, name=nothing; resultfile=nothing)
-    if (resultfile == nothing)
+    if (resultfile === nothing)
         resfile = omc.resultfile
     else
         resfile = resultfile
@@ -780,7 +780,7 @@ function getSolutions(omc, name=nothing; resultfile=nothing)
         return
     end
     if (!isempty(resfile))
-        if (name == nothing)
+        if (name === nothing)
             simresultvars = sendExpression(omc, "readSimulationResultVars(\"" * resfile * "\")")
             sendExpression(omc, "closeSimulationResultFile()")
             return simresultvars
@@ -1162,7 +1162,7 @@ standard getXXX() API
 function which returns the LinearizationOptions
 """
 function getLinearizationOptions(omc, name=nothing)
-    if (name == nothing)
+    if (name === nothing)
         return omc.linearOptions
     elseif (isa(name, String))
         return get(omc.linearOptions, name, 0)

--- a/src/error.jl
+++ b/src/error.jl
@@ -1,0 +1,57 @@
+#=
+This file is part of OpenModelica.
+Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+c/o Linköpings universitet, Department of Computer and Information Science,
+SE-58183 Linköping, Sweden.
+
+All rights reserved.
+
+THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ACCORDING TO RECIPIENTS CHOICE.
+
+The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+Public License (OSMC-PL) are obtained from OSMC, either from the above
+address, from the URLs: http://www.openmodelica.org or
+http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+distribution. GNU version 3 is obtained from:
+http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+http://www.opensource.org/licenses/BSD-3-Clause.
+
+This program is distributed WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+CONDITIONS OF OSMC-PL.
+=#
+
+"""
+omc process error
+"""
+struct OMCError <: Exception
+    cmd::Cmd
+    stdout_file::String
+    stderr_file::String
+end
+"""
+Show error from log files
+"""
+function Base.showerror(io::IO, e::OMCError)
+    println(io, "OMCError ")
+    println(io, "Command $(e.cmd) failed")
+    println(io,  read(e.stdout_file, String))
+    print(io, read(e.stderr_file, String))
+    rm.(["stdout.log", "stderr.log"], force=true)
+end
+
+"""
+Timeout error
+"""
+struct TimeoutError <: Exception
+    msg::String
+end
+function Base.showerror(io::IO, e::TimeoutError)
+  println(io, "TimeoutError")
+  print(e.msg)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,47 +1,38 @@
 module TestOMJulia
+  using OMJulia
+  using Test
 
-using OMJulia
-using Test
+  function check(string, expected_value, expected_type)
+    value = OMJulia.Parser.parseOM(string)
+    expected_value == value && expected_type == typeof(value)
+  end
 
-@testset "OMJulia" begin
+  @testset "OMJulia" begin
+    @testset "Parser" begin
+      @test check("123.0", 123.0, Float64)
+      @test check("123", 123, Int)
+      @test check("1.", 1.0, Float64)
+      @test check(".2", 0.2, Float64)
+      @test check("1e3", 1e3, Float64)
+      @test check("1e+2", 1e+2, Float64)
+      @test check("tRuE", true, Bool)
+      @test check("false", false, Bool)
+      @test check("\"ab\\nc\"", "ab\nc", String)
+      @test check("{\"abc\"}", ["abc"], Array{String,1})
+      @test check("{1}", [1], Array{Int,1})
+      @test check("{1,2,3}", [1,2,3], Array{Int,1})
+      @test check("(1,2,3)", (1,2,3), Tuple{Int,Int,Int})
+      @test check("NONE()", nothing, Nothing)
+      @test check("SOME(1)", 1, Int)
+      @test check("abc_2", :abc_2, Symbol)
+      @test check("record ABC end ABC;", Dict(), Dict{String,Any})
+      @test check("record ABC a = 1, 'b' = 2,\n  c = 3\nend ABC;", Dict("a" => 1, "'b'" => 2, "c" => 3), Dict{String,Int})
+      @test check("", nothing, Nothing)
+    end
 
-@testset "Parser" begin
-
-function check(string, expected_value, expected_type)
-  value = OMJulia.Parser.parseOM(string)
-  expected_value == value && expected_type == typeof(value)
-end
-
-@test check("123.0", 123.0, Float64)
-@test check("123", 123, Int)
-@test check("1.", 1.0, Float64)
-@test check(".2", 0.2, Float64)
-@test check("1e3", 1e3, Float64)
-@test check("1e+2", 1e+2, Float64)
-@test check("tRuE", true, Bool)
-@test check("false", false, Bool)
-@test check("\"ab\\nc\"", "ab\nc", String)
-@test check("{\"abc\"}", ["abc"], Array{String,1})
-@test check("{1}", [1], Array{Int,1})
-@test check("{1,2,3}", [1,2,3], Array{Int,1})
-@test check("(1,2,3)", (1,2,3), Tuple{Int,Int,Int})
-@test check("NONE()", nothing, Nothing)
-@test check("SOME(1)", 1, Int)
-@test check("abc_2", :abc_2, Symbol)
-@test check("record ABC end ABC;", Dict(), Dict{String,Any})
-@test check("record ABC a = 1, 'b' = 2,\n  c = 3\nend ABC;", Dict("a" => 1, "'b'" => 2, "c" => 3), Dict{String,Int})
-@test check("", nothing, Nothing)
-
-end
-
-@testset "OpenModelica" begin
-
-omc = OMJulia.OMCSession()
-
-@test 3==OMJulia.sendExpression(omc, "1+2")
-
-end
-
-end
-
+    @testset "OpenModelica" begin
+      omc = OMJulia.OMCSession()
+      @test 3==OMJulia.sendExpression(omc, "1+2")
+    end
+  end
 end


### PR DESCRIPTION
Fixes #67.

## Changes

  - New error objects for general omc errors and timeout errors.
    - Show full messages from stdout and stderr to user if omc failes to start.
  - Use `==` and `==!` when comparing to `nothing`
  - Fix Project.toml for older Julia 1.0/ 1.1
  - Update version to 0.2.1

```julia
julia> omc=OMJulia.OMCSession()
[ Info: Path to zmq file="/tmp/openmodelica.USER.port.julia.oNnqddn7qq"
ERROR: OMCError
Command `omc --interactive=zmq +z=julia.oNnqddn7qq` failed
Error: You are trying to run OpenModelica as a server using the root user.
This is a very bad idea:
* The socket interface does not authenticate the user.
* OpenModelica allows execution of arbitrary commands.

Execution failed!

Stacktrace:
 [1] OMJulia.OMCSession(omc::Nothing)
   @ OMJulia /workspaces/OMJulia.jl/src/OMJulia.jl:174
 [2] OMJulia.OMCSession()
   @ OMJulia /workspaces/OMJulia.jl/src/OMJulia.jl:89
 [3] top-level scope
   @ REPL[2]:1
```

```julia
julia> omc=OMJulia.OMCSession()
[ Info: Path to zmq file="/tmp/openmodelica.USER.port.julia.jWW4HDd8CY"
ERROR: TimeoutError
ZMQ server port file "/tmp/openmodelica.USER.port.julia.jWW4HDd8CY" not created yet.
Stacktrace:
 [1] OMJulia.OMCSession(omc::Nothing)
   @ OMJulia ~/workdir/julia/OMJulia.jl/src/OMJulia.jl:179
 [2] OMJulia.OMCSession()
   @ OMJulia ~/workdir/julia/OMJulia.jl/src/OMJulia.jl:89
 [3] top-level scope
   @ REPL[2]:1
```