### PR TITLE
Adding Documenter.jl documentation

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.0.5', '1.8']
+        julia-version: ['1.0.5', '1.9']
         julia-arch: ['x64']
         os: ['ubuntu-latest', 'windows-latest']
         omc-version: ['stable']
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: "Set up OpenModelica Compiler"
-        uses: AnHeuermann/setup-openmodelica@v0.4
+        uses: AnHeuermann/setup-openmodelica@v0.6
         with:
           version: ${{ matrix.omc-version }}
           packages: |
@@ -35,6 +35,9 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
+
+      - name: Cache Julia
+        uses: julia-actions/cache@v1
 
       - name: "Build OMJulia"
         uses: julia-actions/julia-buildpkg@v1

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,47 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        julia-version: ['1.9']
+        julia-arch: [x64]
+        os: [ubuntu-latest]
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup OpenModelica
+        uses: AnHeuermann/setup-openmodelica@v0.6
+        with:
+          version: 'nightly'
+          packages: |
+            'omc'
+
+      - name: Setup Julia
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: ${{ matrix.julia-arch }}
+
+      - name: Cache Julia
+        uses: julia-actions/cache@v1
+
+      - name: Install dependencies
+        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+
+      - name: Build and deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token
+        run: julia --project=docs/ docs/make.jl

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-Manifest.toml
+/Manifest.toml
 *.cov

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+/build/
+/omc-temp/

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,0 +1,386 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.9.1"
+manifest_format = "2.0"
+project_hash = "802978382ea37f5cc71ba488b34f39d75e534523"
+
+[[deps.ANSIColoredPrinters]]
+git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
+uuid = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"
+version = "0.0.1"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.1"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[deps.Compat]]
+deps = ["UUIDs"]
+git-tree-sha1 = "e460f044ca8b99be31d35fe54fc33a5c33dd8ed7"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "4.9.0"
+weakdeps = ["Dates", "LinearAlgebra"]
+
+    [deps.Compat.extensions]
+    CompatLinearAlgebraExt = "LinearAlgebra"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.0.2+0"
+
+[[deps.Crayons]]
+git-tree-sha1 = "249fe38abf76d48563e2f4556bebd215aa317e15"
+uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
+version = "4.1.1"
+
+[[deps.DataAPI]]
+git-tree-sha1 = "8da84edb865b0b5b0100c0666a9bc9a0b71c553c"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.15.0"
+
+[[deps.DataFrames]]
+deps = ["Compat", "DataAPI", "DataStructures", "Future", "InlineStrings", "InvertedIndices", "IteratorInterfaceExtensions", "LinearAlgebra", "Markdown", "Missings", "PooledArrays", "PrecompileTools", "PrettyTables", "Printf", "REPL", "Random", "Reexport", "SentinelArrays", "SortingAlgorithms", "Statistics", "TableTraits", "Tables", "Unicode"]
+git-tree-sha1 = "04c738083f29f86e62c8afc341f0967d8717bdb8"
+uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+version = "1.6.1"
+
+[[deps.DataStructures]]
+deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
+git-tree-sha1 = "3dbd312d370723b6bb43ba9d02fc36abade4518d"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.18.15"
+
+[[deps.DataValueInterfaces]]
+git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
+uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
+version = "1.0.0"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[deps.DocStringExtensions]]
+deps = ["LibGit2"]
+git-tree-sha1 = "2fb1e02f2b635d0845df5d7c167fec4dd739b00d"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.9.3"
+
+[[deps.Documenter]]
+deps = ["ANSIColoredPrinters", "Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
+git-tree-sha1 = "39fd748a73dce4c05a9655475e437170d8fb1b67"
+uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+version = "0.27.25"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.6.0"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+
+[[deps.Future]]
+deps = ["Random"]
+uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
+
+[[deps.IOCapture]]
+deps = ["Logging", "Random"]
+git-tree-sha1 = "d75853a0bdbfb1ac815478bacd89cd27b550ace6"
+uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
+version = "0.2.3"
+
+[[deps.InlineStrings]]
+deps = ["Parsers"]
+git-tree-sha1 = "9cc2baf75c6d09f9da536ddf58eb2f29dedaf461"
+uuid = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
+version = "1.4.0"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[deps.InvertedIndices]]
+git-tree-sha1 = "0dc7b50b8d436461be01300fd8cd45aa0274b038"
+uuid = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
+version = "1.3.0"
+
+[[deps.IteratorInterfaceExtensions]]
+git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
+uuid = "82899510-4779-5014-852e-03e436cf321d"
+version = "1.0.0"
+
+[[deps.JLLWrappers]]
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "7e5d6779a1e09a36db2a7b6cff50942a0a7d0fca"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.5.0"
+
+[[deps.JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.4"
+
+[[deps.LaTeXStrings]]
+git-tree-sha1 = "f2355693d6778a178ade15952b7ac47a4ff97996"
+uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+version = "1.3.0"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.3"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "7.84.0+0"
+
+[[deps.LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.10.2+0"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[deps.Libiconv_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "c7cb1f5d892775ba13767a87c7ada0b980ea0a71"
+uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
+version = "1.16.1+2"
+
+[[deps.LightXML]]
+deps = ["Libdl", "XML2_jll"]
+git-tree-sha1 = "e129d9391168c677cd4800f5c0abb1ed8cb3794f"
+uuid = "9c8b4983-aa76-5018-a973-4c85ecc9e179"
+version = "0.9.0"
+
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[deps.MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.2+0"
+
+[[deps.Missings]]
+deps = ["DataAPI"]
+git-tree-sha1 = "f66bdc5de519e8f8ae43bdc598782d35a25b1272"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "1.1.0"
+
+[[deps.Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2022.10.11"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
+
+[[deps.OMJulia]]
+deps = ["DataFrames", "DataStructures", "LightXML", "Random", "ZMQ"]
+path = ".."
+uuid = "0f4fe800-344e-11e9-2949-fb537ad918e1"
+version = "0.2.1"
+
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.21+4"
+
+[[deps.OrderedCollections]]
+git-tree-sha1 = "2e73fe17cac3c62ad1aebe70d44c963c3cfdc3e3"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.6.2"
+
+[[deps.Parsers]]
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "716e24b21538abc91f6205fd1d8363f39b442851"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "2.7.2"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.9.0"
+
+[[deps.PooledArrays]]
+deps = ["DataAPI", "Future"]
+git-tree-sha1 = "a6062fe4063cdafe78f4a0a81cfffb89721b30e7"
+uuid = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
+version = "1.4.2"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "9673d39decc5feece56ef3940e5dafba15ba0f81"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.1.2"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "7eb1686b4f04b82f96ed7a4ea5890a4f0c7a09f1"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.4.0"
+
+[[deps.PrettyTables]]
+deps = ["Crayons", "LaTeXStrings", "Markdown", "Printf", "Reexport", "StringManipulation", "Tables"]
+git-tree-sha1 = "ee094908d720185ddbdc58dbe0c1cbe35453ec7a"
+uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+version = "2.2.7"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[deps.Random]]
+deps = ["SHA", "Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.Reexport]]
+git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "1.2.2"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.SentinelArrays]]
+deps = ["Dates", "Random"]
+git-tree-sha1 = "04bdff0b09c65ff3e06a05e3eb7b120223da3d39"
+uuid = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
+version = "1.4.0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[deps.SortingAlgorithms]]
+deps = ["DataStructures"]
+git-tree-sha1 = "c60ec5c62180f27efea3ba2908480f8055e17cee"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "1.1.1"
+
+[[deps.SparseArrays]]
+deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[deps.Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+version = "1.9.0"
+
+[[deps.StringManipulation]]
+git-tree-sha1 = "46da2434b41f41ac3594ee9816ce5541c6096123"
+uuid = "892a3eda-7b42-436c-8928-eab12a02cf0e"
+version = "0.3.0"
+
+[[deps.SuiteSparse_jll]]
+deps = ["Artifacts", "Libdl", "Pkg", "libblastrampoline_jll"]
+uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
+version = "5.10.1+6"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.TableTraits]]
+deps = ["IteratorInterfaceExtensions"]
+git-tree-sha1 = "c06b2f539df1c6efa794486abfb6ed2022561a39"
+uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+version = "1.0.1"
+
+[[deps.Tables]]
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "OrderedCollections", "TableTraits", "Test"]
+git-tree-sha1 = "1544b926975372da01227b382066ab70e574a3ec"
+uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+version = "1.10.1"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[deps.XML2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "93c41695bc1c08c46c5899f4fe06d6ead504bb73"
+uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
+version = "2.10.3+0"
+
+[[deps.ZMQ]]
+deps = ["FileWatching", "Sockets", "ZeroMQ_jll"]
+git-tree-sha1 = "356d2bdcc0bce90aabee1d1c0f6d6f301eda8f77"
+uuid = "c2297ded-f4af-51ae-bb23-16f91089e4e1"
+version = "1.2.2"
+
+[[deps.ZeroMQ_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "libsodium_jll"]
+git-tree-sha1 = "fe5c65a526f066fb3000da137d5785d9649a8a47"
+uuid = "8f1865be-045e-5c20-9c9f-bfbfb0764568"
+version = "4.3.4+0"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.2.13+0"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.8.0+0"
+
+[[deps.libsodium_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "848ab3d00fe39d6fbc2a8641048f8f272af1c51e"
+uuid = "a9144af2-ca23-56d9-984f-0d03f7b5ccf8"
+version = "1.0.20+0"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.48.0+0"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.4.0+0"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,7 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+OMJulia = "0f4fe800-344e-11e9-2949-fb537ad918e1"
+
+[compat]
+Documenter = "^0.27"
+OMJulia = "^0.2.1"

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,17 @@
+# Documentation
+
+We use Documenter.jl to build the OMJulia documentation that is linked from the
+OpenModelica User's Guide.
+
+## Build and host locally
+
+Make sure you developed OMJulia.jl, so that Documenter.jl is using the correct version to
+build.
+To run Documenter.jl along with LiveServer to render the docs and track any modifications
+run:
+
+```julia
+using Pkg; Pkg.activate("docs/"); Pkg.resolve()
+using OMJulia, LiveServer
+servedocs()
+```

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,23 @@
+using Documenter, OMJulia
+
+ENV["JULIA_DEBUG"]="Documenter"
+
+@info "Make the docs"
+makedocs(
+  sitename = "NonLinearSystemNeuralNetworkFMU.jl",
+  format = Documenter.HTML(edit_link = "master"),
+  workdir = joinpath(@__DIR__,".."),
+  pages = [
+    "Home" => "index.md",
+    "Quickstart" => "quickstart.md",
+    "ModelicaSystem" => "modelicaSystem.md",
+    "sendExpression" => "sendExpression.md"
+  ],
+  modules = [OMJulia],
+)
+
+@info "Deploy the docs"
+deploydocs(
+  repo = "github.com/OpenModelica/OMJulia.jl.git",
+  devbranch = "master"
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,45 @@
+# OMJulia.jl
+
+**Julia scripting OpenModelica interface.**
+
+## Overview
+
+OMJulia - the OpenModelica Julia API is a free, open source, highly portable Julia based
+interactive session handler for Julia scripting of OpenModelica API functionality.
+It provides the modeler with components for creating a complete Julia-Modelica modeling,
+compilation and simulation environment based on the latest OpenModelica implementation and
+Modelica library standard available.
+
+OMJulia is structured to combine both the solving strategy and model building.
+Thus, domain experts (people writing the models) and computational engineers (people
+writing the solver code) can work on one unified tool that is industrially viable for
+optimization of Modelica models, while offering a flexible platform for algorithm
+development and research.
+OMJulia is not a standalone package, it depends upon the OpenModelica installation.
+
+OMJulia is implemented in Julia and depends on ZeroMQ - high performance asynchronous
+messaging library and it supports the Modelica Standard Library version 4.0 that is
+included with OpenModelica.
+
+## Installation
+
+Make sure [OpenModelica](https://openmodelica.org/) is installed.
+
+Install OMJulia.jl with:
+
+```julia
+julia> import Pkg; Pkg.add("OMJulia")
+```
+
+## Features of OMJulia
+
+The OMJulia package contains the following features:
+
+  - Interactive session handling, parsing, interpretation of commands and Modelica
+    expressions for evaluation, simulation, plotting, etc.
+  - Connect with the OpenModelica compiler through zmq sockets
+  - Able to interact with the OpenModelica compiler through the available API
+  - Easy access to the Modelica Standard library.
+  - All the API calls are communicated with the help of the sendExpression method
+    implemented in a Julia module
+  - The results are returned as strings

--- a/docs/src/modelicaSystem.md
+++ b/docs/src/modelicaSystem.md
@@ -1,0 +1,173 @@
+# Advanced API
+
+## ModelicaSystem
+
+```@docs
+ModelicaSystem
+```
+
+```@docs
+OMJulia.OMCSession
+```
+
+### Example
+
+```@repl BouncingBall-example
+using OMJulia
+
+mod = OMJulia.OMCSession()
+omcWorkDoir = mkpath(joinpath("docs", "omc-temp"))  # hide
+mkpath(omcWorkDoir)                                 # hide
+sendExpression(mod, "cd(\"$(omcWorkDoir)\")")       # hide
+ModelicaSystem(mod,
+               joinpath("docs", "testmodels", "BouncingBall.mo"),
+               "BouncingBall")
+```
+
+## WorkDirectory
+
+For each OMJulia session a temporary work directory is created and the results are
+published in that working directory.
+In order to get the work directory use [`getWorkDirectory`](@ref).
+
+```@docs
+getWorkDirectory
+```
+
+## Build Model
+
+In case the Modelica model needs to be updated or additional simulation flags needs to be
+set using [`sendExpression`](@ref) The [`buildModel`](@ref) API can be used after
+[`ModelicaSystem`](@ref).
+
+```@docs
+buildModel
+```
+
+## Get Methods
+
+```@docs
+getQuantities
+showQuantities
+getContinuous
+getInputs
+getOutputs
+getParameters
+getSimulationOptions
+getSolutions
+```
+
+### Examples
+
+```@repl BouncingBall-example
+getQuantities(mod)
+getQuantities(mod, "height")
+getQuantities(mod, ["c","radius"])
+showQuantities(mod)
+```
+
+```@repl BouncingBall-example
+getContinuous(mod)
+getContinuous(mod, ["velocity","height"])
+```
+
+```@repl BouncingBall-example
+getInputs(mod)
+getOutputs(mod)
+```
+
+```@repl BouncingBall-example
+getParameters(mod)
+getParameters(mod, ["c","radius"])
+```
+
+```@repl BouncingBall-example
+getSimulationOptions(mod)
+getSimulationOptions(mod, ["stepSize","tolerance"])
+```
+
+```@repl BouncingBall-example
+getSolutions(mod)
+getSolutions(mod, ["time","height"])
+```
+
+## Set Methods
+
+```@docs
+setInputs()
+setParameters()
+setSimulationOptions()
+```
+
+### Examples
+
+```@repl BouncingBall-example
+setInputs(mod, "cAi=1")
+setInputs(mod, ["cAi=1","Ti=2"])
+```
+
+```@repl BouncingBall-example
+setParameters(mod, "radius=14")
+setParameters(mod, ["radius=14","c=0.5"])
+```
+
+```@repl BouncingBall-example
+setSimulationOptions(mod, ["stopTime=2.0","tolerance=1e-08"])
+```
+
+## Simulation
+
+```@docs
+simulate
+```
+
+### Examples
+
+```@repl BouncingBall-example
+simulate(mod, simflags="-noEventEmit -noRestart -override=e=0.3,g=9.71")
+```
+
+
+## Linearization
+
+```@docs
+linearize()
+getLinearizationOptions()
+setLinearizationOptions()
+getLinearInputs()
+getLinearOutputs()
+getLinearStates()
+```
+
+### Examples
+
+```@repl BouncingBall-example
+getLinearizationOptions(mod) 
+getLinearizationOptions(mod, ["startTime","stopTime"])
+```
+
+```@repl BouncingBall-example
+setLinearizationOptions(mod,["stopTime=2.0","tolerance=1e-06"])
+```
+
+```@repl BouncingBall-example
+linearize(mod)
+```
+
+```@repl BouncingBall-example
+getLinearInputs(mod)
+getLinearOutputs(mod)
+getLinearStates(mod)
+```
+
+## Sensitivity Analysis
+
+```@docs
+sensitivity
+```
+
+### Examples
+
+```@repl BouncingBall-example
+(Sn, Sa) = sensitivity(mod, ["UA","EdR"], ["T","cA"], [1e-2,1e-4])
+```

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -1,0 +1,84 @@
+# Quickstart
+
+## ModelicaSystem
+
+To simulate Modelica model `BouncingBall`
+
+```modelica
+model BouncingBall
+  parameter Real e=0.7 "coefficient of restitution";
+  parameter Real g=9.81 "gravity acceleration";
+  Real h(fixed=true, start=1) "height of ball";
+  Real v(fixed=true) "velocity of ball";
+  Boolean flying(fixed=true, start=true) "true, if ball is flying";
+  Boolean impact;
+  Real v_new(fixed=true);
+  Integer foo;
+
+equation
+  impact = h <= 0.0;
+  foo = if impact then 1 else 2;
+  der(v) = if flying then -g else 0;
+  der(h) = v;
+
+  when {h <= 0.0 and v <= 0.0,impact} then
+    v_new = if edge(impact) then -e*pre(v) else 0;
+    flying = v_new > 0;
+    reinit(v, v_new);
+  end when;
+
+end BouncingBall;
+```
+
+!!! info
+    The BouncingBall.mo file can be found in your OpenModelica installation directory in
+    `<OpenModelcia>/share/doc/omc/testmodels/BouncingBall.mo`
+
+
+start a new [`OMCSession`](@ref) and create a new [`ModelicaSystem`](@ref) to build the
+BouncingBall model.
+
+```@repl
+using OMJulia
+
+mod = OMJulia.OMCSession()
+omcWorkDoir = mkpath(joinpath("docs", "omc-temp"))  # hide
+mkpath(omcWorkDoir)                                 # hide
+sendExpression(mod, "cd(\"$(omcWorkDoir)\")")       # hide
+ModelicaSystem(mod,
+               joinpath("docs", "testmodels", "BouncingBall.mo"),
+               "BouncingBall")
+```
+
+## Scripting API with sendExpression
+
+Start a new `OMCSession` and send
+[scripting API](https://openmodelica.org/doc/OpenModelicaUsersGuide/latest/scripting_api.html)
+expressions to the omc session with `sendExpression()`.
+
+```@repl
+using OMJulia
+
+omc = OMJulia.OMCSession()
+sendExpression(omc, "loadModel(Modelica)")
+omcWorkDoir = mkpath(joinpath("docs", "omc-temp"))  # hide
+mkpath(omcWorkDoir)                                 # hide
+sendExpression(omc, "cd(\"$(omcWorkDoir)\")")       # hide
+sendExpression(omc, "model a Real s; equation s=sin(10*time); end a;")
+sendExpression(omc, "simulate(a)")
+OMJulia.sendExpression(omc, "quit()", parsed=false)
+```
+
+!!! info
+    Special characters in string arguments need to be escaped. E.g. `"` becomes `\"`.
+    For example scripting API call
+
+    ```modelica
+    loadFile("/path/to/M.mo")
+    ```
+
+    will translate to
+
+    ```julia
+    sendExpression(omc, "loadFile(\"/path/to/M.mo\")")
+    ```

--- a/docs/src/sendExpression.md
+++ b/docs/src/sendExpression.md
@@ -1,0 +1,9 @@
+# sendExpression
+
+Start a new `OMCSession` and send
+[scripting API](https://openmodelica.org/doc/OpenModelicaUsersGuide/latest/scripting_api.html)
+expressions to the omc session with `sendExpression()`.
+
+```@docs
+sendExpression
+```

--- a/docs/testmodels/BouncingBall.mo
+++ b/docs/testmodels/BouncingBall.mo
@@ -1,0 +1,23 @@
+model BouncingBall
+  parameter Real e=0.7 "coefficient of restitution";
+  parameter Real g=9.81 "gravity acceleration";
+  Real h(fixed=true, start=1) "height of ball";
+  Real v(fixed=true) "velocity of ball";
+  Boolean flying(fixed=true, start=true) "true, if ball is flying";
+  Boolean impact;
+  Real v_new(fixed=true);
+  Integer foo;
+
+equation
+  impact = h <= 0.0;
+  foo = if impact then 1 else 2;
+  der(v) = if flying then -g else 0;
+  der(h) = v;
+
+  when {h <= 0.0 and v <= 0.0,impact} then
+    v_new = if edge(impact) then -e*pre(v) else 0;
+    flying = v_new > 0;
+    reinit(v, v_new);
+  end when;
+
+end BouncingBall;

--- a/src/modelicaSystem.jl
+++ b/src/modelicaSystem.jl
@@ -1,0 +1,1129 @@
+#=
+This file is part of OpenModelica.
+Copyright (c) 1998-2023, Open Source Modelica Consortium (OSMC),
+c/o Linköpings universitet, Department of Computer and Information Science,
+SE-58183 Linköping, Sweden.
+
+All rights reserved.
+
+THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ACCORDING TO RECIPIENTS CHOICE.
+
+The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+Public License (OSMC-PL) are obtained from OSMC, either from the above
+address, from the URLs: http://www.openmodelica.org or
+http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+distribution. GNU version 3 is obtained from:
+http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+http://www.opensource.org/licenses/BSD-3-Clause.
+
+This program is distributed WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+CONDITIONS OF OSMC-PL.
+=#
+
+"""
+    ModelicaSystem(omc, filename, modelname, library=nothing;
+                   actcommandLineOptions=nothing, variableFilter=nothing)
+
+Set command line options for OMCSession and build model `modelname` to prepare for a simulation.
+
+## Arguments
+
+- `omc`:       OpenModelica compiler session, see `OMCSession()`.
+- `filename`:  Path to Modelica file.
+- `modelname`: Name of Modelica model to build, including namespace if the
+               model is wrappen within a Modelica package.
+- `library`:   List of dependent libraries or Modelica files.
+               This argument can be passed as string (e.g. `"Modelica"`)
+               or tuple (e.g. `("Modelica", "4.0")`
+               or array (e.g. ` ["Modelica", "SystemDynamics"]`
+               or `[("Modelica", "4.0"), "SystemDynamics"]`).
+
+## Keyword Arguments
+
+- `commandLineOptions`: OpenModelica command line options, see
+                        [OpenModelica Compiler Flags](https://openmodelica.org/doc/OpenModelicaUsersGuide/latest/omchelptext.html).
+- `variableFilter`:     Regex to filter variables in result file.
+
+## Usage
+
+```
+using OMJulia
+mod = OMJulia.OMCSession()
+ModelicaSystem(mod, "BouncingBall.mo", "BouncingBall", ["Modelica", "SystemDynamics"], commandLineOptions="-d=newInst")
+```
+
+Providing dependent libaries:
+
+```
+using OMJulia
+mod = OMJulia.OMCSession()
+ModelicaSystem(mod, "BouncingBall.mo", "BouncingBall", ["Modelica", "SystemDynamics", "dcmotor.mo"])
+```
+
+See also [`OMCSession()`](@ref).
+"""
+function ModelicaSystem(omc::OMCSession,
+                        filename::AbstractString,
+                        modelname::AbstractString,
+                        library::Union{AbstractString, Tuple{AbstractString, AbstractString}, Array{AbstractString}, Array{Tuple{AbstractString, AbstractString}}, Nothing} = nothing;
+                        commandLineOptions::Union{AbstractString, Nothing} = nothing,
+                        variableFilter::Union{AbstractString, Nothing} = nothing)
+
+    ## check for commandLineOptions
+    if (commandLineOptions !== nothing)
+        exp = join(["setCommandLineOptions(","","\"",commandLineOptions,"\"" ,")"])
+        cmdexp = sendExpression(omc, exp)
+        if (!cmdexp)
+            return println(sendExpression(omc, "getErrorString()"))
+        end
+    end
+
+    ## set default command Line Options for linearization as
+    ## linearize() will use the simulation executable and runtime
+    ## flag -l to perform linearization
+    sendExpression(omc, "setCommandLineOptions(\"--linearizationDumpLanguage=julia\")")
+    sendExpression(omc, "setCommandLineOptions(\"--generateSymbolicLinearization\")")
+
+    omc.filepath = filename
+    omc.modelname = modelname
+    omc.variableFilter = variableFilter
+    filepath = replace(abspath(filename), r"[/\\]+" => "/")
+    if (isfile(filepath))
+        loadmsg = sendExpression(omc, "loadFile(\"" * filepath * "\")")
+        if (!loadmsg)
+            return println(sendExpression(omc, "getErrorString()"))
+        end
+    else
+        return println(filename, "! NotFound")
+    end
+    omc.tempdir = replace(mktempdir(), r"[/\\]+" => "/")
+    if (!isdir(omc.tempdir))
+        return println(omc.tempdir, " cannot be created")
+    end
+    sendExpression(omc, "cd(\"" * omc.tempdir * "\")")
+    # load Libraries provided by users
+    if (library !== nothing)
+        if (isa(library, AbstractString))
+            loadLibraryHelper(omc, library)
+        # allow users to provide library version e.g. ("Modelica", "3.2.3")
+        elseif (isa(library, Tuple{AbstractString, AbstractString}))
+            if (!isempty(library[2]))
+                loadLibraryHelper(omc, library[1], library[2])
+            else
+                loadLibraryHelper(omc, library[1])
+            end
+        elseif (isa(library, Array))
+            for i in library
+                # allow users to provide library version e.g. ("Modelica", "3.2.3")
+                if isa(i, Tuple{AbstractString, AbstractString})
+                    if (!isempty(i[2]))
+                        loadLibraryHelper(omc, i[1], i[2])
+                    else
+                        loadLibraryHelper(omc, i[1])
+                    end
+                elseif isa(i, AbstractString)
+                    loadLibraryHelper(omc, i)
+                else
+                    error("Unknown type detected in input argument library[$i]. Is of type $(typeof(i))")
+                end
+            end
+        else
+            error("Unknown type detected in input argument library[$i]. Is of type $(typeof(i))")
+        end
+    end
+    buildModel(omc)
+end
+
+function loadLibraryHelper(omc, libname, version=nothing)
+    if (isfile(libname))
+        libfile = replace(abspath(libname), r"[/\\]+" => "/")
+        libfilemsg = sendExpression(omc, "loadFile(\"" * libfile * "\")")
+        if (!libfilemsg)
+            return println(sendExpression(omc, "getErrorString()"))
+        end
+    else
+        if version === nothing
+            libname = join(["loadModel(", libname, ")"])
+        else
+            libname = join(["loadModel(", libname, ", ", "{", "\"", version, "\"", "}", ")"])
+        end
+        #println(libname)
+        result = sendExpression(omc, libname)
+        if (!result)
+            return println(sendExpression(omc, "getErrorString()"))
+        end
+    end
+end
+
+
+"""
+Standard buildModel API which builds the modelica model
+"""
+function buildModel(omc; variableFilter=nothing)
+    if (variableFilter !== nothing)
+        omc.variableFilter = variableFilter
+    end
+    # println(omc.variableFilter)
+
+    if (omc.variableFilter !== nothing)
+        varFilter = join(["variableFilter=", "\"", omc.variableFilter, "\""])
+    else
+        varFilter = join(["variableFilter=\"", ".*" ,"\""])
+    end
+    # println(varFilter)
+
+    buildmodelexpr = join(["buildModel(",omc.modelname,", ", varFilter,")"])
+    # println(buildmodelexpr)
+
+    buildModelmsg = sendExpression(omc, buildmodelexpr)
+    # parsebuilexp=Base.Meta.parse(buildModelmsg)
+    if (!isempty(buildModelmsg[2]))
+        omc.xmlfile = replace(joinpath(omc.tempdir, buildModelmsg[2]), r"[/\\]+" => "/")
+        xmlparse(omc)
+    else
+        return println(sendExpression(omc, "getErrorString()"))
+    end
+end
+
+"""
+This function parses the XML file generated from the buildModel()
+and stores the model variable into different categories namely parameter
+inputs, outputs, continuous etc..
+"""
+function xmlparse(omc)
+    if (isfile(omc.xmlfile))
+        xdoc = parse_file(omc.xmlfile)
+        # get the root element
+        xroot = root(xdoc)  # an instance of XMLElement
+        for c in child_nodes(xroot)  # c is an instance of XMLNode
+            if is_elementnode(c)
+                e = XMLElement(c)  # this makes an XMLElement instance
+                if (name(e) == "DefaultExperiment")
+                    omc.simulateOptions["startTime"] = attribute(e, "startTime")
+                    omc.simulateOptions["stopTime"] = attribute(e, "stopTime")
+                    omc.simulateOptions["stepSize"] = attribute(e, "stepSize")
+                    omc.simulateOptions["tolerance"] = attribute(e, "tolerance")
+                    omc.simulateOptions["solver"] = attribute(e, "solver")
+                end
+                if (name(e) == "ModelVariables")
+                    for r in child_elements(e)
+                        scalar = Dict()
+                        scalar["name"] = attribute(r, "name")
+                        scalar["changeable"] = attribute(r, "isValueChangeable")
+                        scalar["description"] = attribute(r, "description")
+                        scalar["variability"] = attribute(r, "variability")
+                        scalar["causality"] = attribute(r, "causality")
+                        scalar["alias"] = attribute(r, "alias")
+                        scalar["aliasvariable"] = attribute(r, "aliasVariable")
+                        subchild = child_elements(r)
+                        for s in subchild
+                            value = attribute(s, "start")
+                            min = attribute(s, "min")
+                            max = attribute(s, "max")
+                            if (value !== nothing)
+                                scalar["start"] = value
+                            else
+                                scalar["start"] = "None"
+                            end
+                            if (min !== nothing)
+                                scalar["min"] = min
+                            else
+                                scalar["min"] = "None"
+                            end
+                            if (max !== nothing)
+                                scalar["max"] = max
+                            else
+                                scalar["max"] = "None"
+                            end
+                        end
+                        if (omc.linearFlag == false)
+                            if (scalar["variability"] == "parameter")
+                                if haskey(omc.overridevariables, scalar["name"])
+                                    omc.parameterlist[scalar["name"]] = omc.overridevariables[scalar["name"]]
+                                else
+                                    omc.parameterlist[scalar["name"]] = scalar["start"]
+                                end
+                            end
+                            if (scalar["variability"] == "continuous")
+                                omc.continuouslist[scalar["name"]] = scalar["start"]
+                            end
+                            if (scalar["causality"] == "input")
+                                omc.inputlist[scalar["name"]] = scalar["start"]
+                            end
+                            if (scalar["causality"] == "output")
+                                omc.outputlist[scalar["name"]] = scalar["start"]
+                            end
+                        end
+                        push!(omc.quantitieslist, scalar)
+                    end
+                end
+            end
+        end
+        # return quantities
+    else
+        println("file not generated")
+        return
+    end
+end
+
+"""
+standard getXXX() API
+function which return list of all variables parsed from xml file
+"""
+function getQuantities(omc, name=nothing)
+    if (name === nothing)
+        return omc.quantitieslist
+    elseif (isa(name, String))
+        return [x for x in omc.quantitieslist if x["name"] == name]
+    elseif (isa(name, Array))
+        return [x for y in name for x in omc.quantitieslist if x["name"] == y]
+    end
+end
+
+function getQuantitiesHelper(omc, name=nothing; verbose=true)
+    for x in omc.quantitieslist
+        if (x["name"] == name)
+            return x
+        end
+    end
+    if verbose
+        println("| info | getQuantities() failed: ", "\"", name, "\"", " does not exist")
+    end
+    return []
+end
+
+"""
+standard getXXX() API
+function same as getQuantities(), but returns all the variables as table
+"""
+function showQuantities(omc, name=nothing)
+    q = getQuantities(omc, name);
+    # assuming that the keys of the first dictionary is representative for them all
+    sym = map(Symbol, collect(keys(q[1])))
+    arr = []
+    for d in q
+        push!(arr, Dict(zip(sym, values(d))))
+    end
+    return df_from_dicts(arr)
+end
+
+
+## helper function to return getQuantities as table
+function df_from_dicts(arr::AbstractArray; missing_value="missing")
+    cols = Set{Symbol}()
+    for di in arr union!(cols, keys(di)) end
+    df = DataFrame()
+    for col = cols
+      # df[col] = [get(di, col, missing_value) for di=arr]
+        df[!,col] = [get(di, col, missing_value) for di = arr]
+    end
+    return df
+end
+
+"""
+standard getXXX() API
+function which returns the parameter variables parsed from xmlfile
+"""
+function getParameters(omc, name=nothing)
+    if (name === nothing)
+        return omc.parameterlist
+    elseif (isa(name, String))
+        return get(omc.parameterlist, name, 0)
+    elseif (isa(name, Array))
+        return [get(omc.parameterlist, x, 0) for x in name]
+    end
+end
+
+"""
+standard getXXX() API
+function which returns the SimulationOption variables parsed from xmlfile
+"""
+function getSimulationOptions(omc, name=nothing)
+    if (name === nothing)
+        return omc.simulateOptions
+    elseif (isa(name, String))
+        return get(omc.simulateOptions, name, 0)
+    elseif (isa(name, Array))
+        return [get(omc.simulateOptions, x, 0) for x in name]
+    end
+end
+
+"""
+standard getXXX() API
+function which returns the continuous variables parsed from xmlfile
+"""
+function getContinuous(omc, name=nothing)
+    if (omc.simulationFlag == false)
+        if (name === nothing)
+            return omc.continuouslist
+        elseif (isa(name, String))
+            return get(omc.continuouslist, name, 0)
+        elseif (isa(name, Array))
+            return [get(omc.continuouslist, x, 0) for x in name]
+        end
+    end
+    if (omc.simulationFlag == true)
+        if (name === nothing)
+            for name in keys(omc.continuouslist)
+                ## failing for variables with $ sign
+                ## println(name)
+                try
+                    value = getSolutions(omc, name)
+                    value1 = value[1]
+                    omc.continuouslist[name] = value1[end]
+                catch Exception
+                    println(Exception)
+                end
+            end
+            return omc.continuouslist
+        elseif (isa(name, String))
+            if (haskey(omc.continuouslist, name))
+                value = getSolutions(omc, name)
+                value1 = value[1]
+                omc.continuouslist[name] = value1[end]
+                return get(omc.continuouslist, name, 0)
+            else
+                return println(name, "  is not continuous")
+            end
+        elseif (isa(name, Array))
+            continuousvaluelist = Any[]
+            for x in name
+                if (haskey(omc.continuouslist, x))
+                    value = getSolutions(omc, x)
+                    value1 = value[1]
+                    omc.continuouslist[x] = value1[end]
+                    push!(continuousvaluelist, value1[end])
+                else
+                    return println(x, "  is not continuous")
+                end
+            end
+            return continuousvaluelist
+        end
+    end
+end
+
+"""
+standard getXXX() API
+function which returns the input variables parsed from xmlfile
+"""
+function getInputs(omc, name=nothing)
+    if (name === nothing)
+        return omc.inputlist
+    elseif (isa(name, String))
+        return get(omc.inputlist, name, 0)
+    elseif (isa(name, Array))
+        return [get(omc.inputlist, x, 0) for x in name]
+    end
+end
+
+"""
+standard getXXX() API
+function which returns the output variables parsed from xmlfile
+"""
+function getOutputs(omc, name=nothing)
+    if (omc.simulationFlag == false)
+        if (name === nothing)
+            return omc.outputlist
+        elseif (isa(name, String))
+            return get(omc.outputlist, name, 0)
+        elseif (isa(name, Array))
+            return [get(omc.outputlist, x, 0) for x in name]
+        end
+    end
+    if (omc.simulationFlag == true)
+        if (name === nothing)
+            for name in keys(omc.outputlist)
+                value = getSolutions(omc, name)
+                value1 = value[1]
+                omc.outputlist[name] = value1[end]
+            end
+            return omc.outputlist
+        elseif (isa(name, String))
+            if (haskey(omc.outputlist, name))
+                value = getSolutions(omc, name)
+                value1 = value[1]
+                omc.outputlist[name] = value1[end]
+                return get(omc.outputlist, name, 0)
+            else
+                return println(name, "is not Output")
+            end
+        elseif (isa(name, Array))
+            valuelist = Any[]
+            for x in name
+                if (haskey(omc.outputlist, x))
+                    value = getSolutions(omc, x)
+                    value1 = value[1]
+                    omc.outputlist[x] = value1[end]
+                    push!(valuelist, value1[end])
+                else
+                    return println(x, "is not Output")
+                end
+            end
+            return valuelist
+        end
+    end
+end
+
+"""
+    simulate(omc; resultfile=nothing, simflags=nothing, verbose=true)
+
+Simulate modelica model.
+
+## Arguments
+
+- `omc`:        OpenModelica compiler session, see `OMCSession()`.
+
+## Keyword Arguments
+
+- `resultFile`: Result file to write simulation results into.
+- `simflags`:   Simulation flags, see [Simulation Runtime Flags](https://openmodelica.org/doc/OpenModelicaUsersGuide/latest/simulationflags.html).
+
+## Examples
+
+```julia
+simulate(omc)
+```
+
+Specify result file:
+
+```julia
+simulate(omc, resultfile="tmpresult.mat")
+```
+
+Set simulation runtime flags:
+
+```julia
+simulate(omc, simflags="-noEmitEvent -override=e=0.3,g=9.3")
+```
+"""
+function simulate(omc; resultfile=nothing, simflags=nothing, verbose=true)
+    # println(this.xmlfile)
+    if (resultfile === nothing)
+        r = ""
+        omc.resultfile = replace(joinpath(omc.tempdir, join([omc.modelname,"_res.mat"])), r"[/\\]+" => "/")
+    else
+        r = join(["-r=",resultfile])
+        omc.resultfile = replace(joinpath(omc.tempdir, resultfile), r"[/\\]+" => "/")
+    end
+
+    if (simflags === nothing)
+        simflags = ""
+    end
+
+    if (isfile(omc.xmlfile))
+        if (Base.Sys.iswindows())
+            getexefile = replace(joinpath(omc.tempdir, join([omc.modelname,".exe"])), r"[/\\]+" => "/")
+        else
+            getexefile = replace(joinpath(omc.tempdir, omc.modelname), r"[/\\]+" => "/")
+        end
+        if (isfile(getexefile))
+            ## change to tempdir
+            cd(omc.tempdir)
+            if (!isempty(omc.overridevariables) | !isempty(omc.simoptoverride))
+                tmpdict = merge(omc.overridevariables, omc.simoptoverride)
+                overridefile = replace(joinpath(omc.tempdir, join([omc.modelname,"_override.txt"])), r"[/\\]+" => "/")
+                file = open(overridefile, "w")
+                for k in keys(tmpdict)
+                    val = join([k,"=",tmpdict[k],"\n"])
+                    println(val)
+                    write(file, val)
+                end
+                close(file)
+                overridevar = join(["-overrideFile=", overridefile])
+            else
+                overridevar = ""
+            end
+            if (omc.inputFlag == true)
+                createcsvdata(omc, omc.simulateOptions["startTime"], omc.simulateOptions["stopTime"])
+                csvinput = join(["-csvInput=",omc.csvfile])
+                # run(pipeline(`$getexefile $overridevar $csvinput`,stdout="log.txt",stderr="error.txt"))
+            else
+                csvinput = ""
+                # run(pipeline(`$getexefile $overridevar`,stdout="log.txt",stderr="error.txt"))
+            end
+            # remove empty args in cmd objects
+            cmd = filter!(e -> e ≠ "", [getexefile,overridevar,csvinput,r,simflags])
+            # println(cmd)
+            if (Base.Sys.iswindows())
+                installPath = sendExpression(omc, "getInstallationDirectoryPath()")
+                envPath = ENV["PATH"]
+                newPath = "$(envPath);$(installPath)/bin/;$(installPath)/lib/omc;$(installPath)/lib/omc/cpp;$(installPath)/lib/omc/omsicpp"
+                # println("Path: $newPath")
+                withenv("PATH" => newPath) do
+                    if verbose
+                        run(pipeline(`$cmd`))
+                    else
+                        run(pipeline(`$cmd`, stdout="log.txt", stderr="error.txt"))
+                    end
+                end
+            else
+                if verbose
+                    run(pipeline(`$cmd`))
+                else
+                    run(pipeline(`$cmd`, stdout="log.txt", stderr="error.txt"))
+                end
+            end
+            # omc.resultfile=replace(joinpath(omc.tempdir,join([omc.modelname,"_res.mat"])),r"[/\\]+" => "/")
+            omc.simulationFlag = true
+        else
+            return println("! Simulation Failed")
+        end
+        ## change to currentworkingdirectory
+        cd(omc.currentdir)
+    end
+end
+
+"""
+function which converts modelicamodel to FMU
+"""
+function convertMo2FMU(omc)
+    if (!isempty(omc.modelname))
+        fmuexpression = join(["translateModelFMU(",omc.modelname,")"])
+        sendExpression(omc, fmuexpression)
+    else
+        println(sendExpression(omc, "getErrorString()"))
+    end
+end
+
+"""
+function which converts FMU to modelicamodel
+"""
+function convertFmu2Mo(omc, fmupath)
+    fmupath = replace(abspath(fmupath), r"[/\\]+" => "/")
+    if (isfile(fmupath))
+        result = sendExpression(omc, "importFMU(\"" * fmupath * "\")")
+        return joinpath(omc.tempdir, result)
+    else
+        println(fmupath, " ! Fmu not Found")
+    end
+end
+
+"""
+Method for computing numeric sensitivity of OpenModelica object
+
+   Arguments:
+   ----------
+   1st arg: Vp  # Array of strings of Modelica Parameter names
+   2nd arg: Vv  # Array of strings of Modelica Variable names
+   3rd arg: Ve  # Array of float Excitations of parameters; defaults to scalar 1e-2
+
+   Returns:
+   --------
+   1st return: VSname # Vector of Sensitivity names
+   2nd return: Sarray # Array of sensitivies: vector of elements per parameter,
+   each element containing time series per variable
+"""
+function sensitivity(omc, Vp, Vv, Ve=[1e-2])
+    ## Production quality code should check type and form of input arguments
+    Ve = map(Float64, Ve) # converting eVements of excitation to floats
+    nVp = length(Vp) # number of parameter names
+    nVe = length(Ve) # number of excitations in parameters
+    # Adjusting size of Ve to that of Vp
+    if nVe < nVp
+        push!(Ve, Ve[end] * ones(nVp - nVe)...) # extends Ve by adding last eVement of Ve
+    elseif nVe > nVp
+         Ve = Ve[1:nVp] # truncates Ve to same length as Vp
+    end
+    # Nominal parameters p0
+    par0 = [Base.parse(Float64, pp) for pp in getParameters(omc, Vp)]
+    # eXcitation parameters parX
+    parX = [par0[i] * (1 + Ve[i]) for i in 1:nVp]
+    # Combine parameter names and parameter values into vector of strings
+    Vpar0 = [Vp[i] * "=$(par0[i])" for i in 1:nVp]
+    VparX = [Vp[i] * "=$(parX[i])" for i in 1:nVp]
+    # Simulate nominal system
+    simulate(omc)
+    # Get nominal SOLutions of variabVes of interest (Vv), converted to 2D array
+    sol0 = getSolutions(omc, Vv)
+    # Get vector of eXcited SOLutions (2D arrays), one for each parameter (Vp)
+    solX = Vector{Array{Array{Float64,1},1}}()
+    for p in VparX
+         # change to excited parameter
+        setParameters(omc, p)
+         # simulate perturbed system
+        simulate(omc)
+         # get eXcited SOLutions (Vv) as 2D array, and append to list
+        push!(solX, getSolutions(omc, Vv))
+         # reset parameters to nominal values
+        setParameters(omc, Vpar0)
+    end
+    ## Compute sensitivities and add to vector, one 2D array per parameter (Vp)
+    VSname = Vector{Vector{String}}()
+    VSarray = Vector{Array{Array{Float64,1},1}}() # same shape as solX
+    for (i, sol) in enumerate(solX)
+        push!(VSarray, ((sol - sol0) / (par0[i] * Ve[i])))
+        vsname = Vector{String}()
+        for j in 1:nVp
+            push!(vsname, "Sensitivity." * Vp[i] * "." * Vv[j])
+        end
+        push!(VSname, vsname)
+    end
+    return VSname, VSarray
+end
+
+"""
+standard getXXX() API
+Function which reads the result file and return the simulation results to user
+which can be used for plotting or further anlaysis
+"""
+function getSolutions(omc, name=nothing; resultfile=nothing)
+    if (resultfile === nothing)
+        resfile = omc.resultfile
+    else
+        resfile = resultfile
+    end
+    if (!isfile(resfile))
+        println("ResultFile does not exist !", abspath(resfile))
+        return
+    end
+    if (!isempty(resfile))
+        simresultvars = sendExpression(omc, "readSimulationResultVars(\"" * resfile * "\")")
+        sendExpression(omc, "closeSimulationResultFile()")
+        if (name === nothing)
+            return simresultvars
+        elseif (isa(name, String))
+            if (!(name in simresultvars) && name != "time")
+                println(name, " does not exist\n")
+                return
+            end
+            resultvar = join(["{",name,"}"])
+            simres = sendExpression(omc, "readSimulationResult(\"" * resfile * "\"," * resultvar * ")")
+            sendExpression(omc, "closeSimulationResultFile()")
+            return simres
+        elseif (isa(name, Array))
+            for var in name
+                if (!(var in simresultvars) && var != "time")
+                    println(var, " does not exist\n")
+                    return
+                end
+            end
+            resultvar = join(["{",join(name, ","),"}"])
+            # println(resultvar)
+            simres = sendExpression(omc, "readSimulationResult(\"" * resfile * "\"," * resultvar * ")")
+            sendExpression(omc, "closeSimulationResultFile()")
+            return simres
+        end
+    else
+        return println("Model not Simulated, Simulate the model to get the results")
+    end
+end
+
+"""
+standard setXXX() API
+function which sets new Parameter values for parameter variables defined by users
+"""
+function setParameters(omc, name;verbose=true)
+    if (isa(name, String))
+        name = strip_space(name)
+        value = split(name, "=")
+        # setxmlfileexpr="setInitXmlStartValue(\""* this.xmlfile * "\",\""* value[1]* "\",\""*value[2]*"\",\""*this.xmlfile*"\")"
+        # println(haskey(this.parameterlist, value[1]))
+        if (haskey(omc.parameterlist, value[1]))
+            # should we use this ???
+            # setparameterValue = join(["setParameterValue(",omc.modelname,",", value[1],",",value[2],")"])
+            # println(setparameterValue)
+            if (isParameterChangeable(omc, value[1], value[2]))
+                omc.parameterlist[value[1]] = value[2]
+                omc.overridevariables[value[1]] = value[2]
+            end
+        else
+            if verbose
+                println("| info |  setParameters() failed: ", "\"", value[1], "\"", " is not a parameter")
+            end
+        end
+    # omc.sendExpression(setxmlfileexpr)
+    elseif (isa(name, Array))
+        name = strip_space(name)
+        for var in name
+            value = split(var, "=")
+            if (haskey(omc.parameterlist, value[1]))
+                if (isParameterChangeable(omc, value[1], value[2]))
+                    omc.parameterlist[value[1]] = value[2]
+                    omc.overridevariables[value[1]] = value[2]
+                end
+            else
+                if verbose
+                    println("| info |  setParameters() failed: ", "\"", value[1], "\"", " is not a parameter")
+                end
+            end
+        end
+    end
+end
+
+"""
+check for parameter modifiable or not
+"""
+function isParameterChangeable(omc, name, value; verbose=true)
+    q = getQuantities(omc, String(name))
+    if (isempty(q))
+        println(name, " does not exist in the model")
+        return false
+    elseif (q[1]["changeable"] == "false")
+        if verbose
+            println("| info |  setParameters() failed : It is not possible to set the following signal ", "\"", name, "\"", ", It seems to be structural, final, protected or evaluated or has a non-constant binding, use sendExpression(setParameterValue(", omc.modelname, ", ", name, ", ", value, "), parsed=false)", " and rebuild the model using buildModel() API")
+        end
+        return false
+    end
+    return true
+end
+
+"""
+standard setXXX() API
+function which sets new Simulation Options values defined by users
+"""
+function setSimulationOptions(omc, name)
+    if (isa(name, String))
+        name = strip_space(name)
+        value = split(name, "=")
+        if (haskey(omc.simulateOptions, value[1]))
+            omc.simulateOptions[value[1]] = value[2]
+            omc.simoptoverride[value[1]] = value[2]
+        else
+            return println(value[1], "  is not a SimulationOption")
+        end
+    elseif (isa(name, Array))
+        name = strip_space(name)
+        for var in name
+            value = split(var, "=")
+            if (haskey(omc.simulateOptions, value[1]))
+                omc.simulateOptions[value[1]] = value[2]
+                omc.simoptoverride[value[1]] = value[2]
+            else
+                return println(value[1], "  is not a SimulationOption")
+            end
+        end
+    end
+end
+
+"""
+standard setXXX() API
+function which sets new input values for input variables defined by users
+"""
+function setInputs(omc, name)
+    if (isa(name, String))
+        name = strip_space(name)
+        value = split(name, "=")
+        if (haskey(omc.inputlist, value[1]))
+            newval = Base.Meta.parse(value[2])
+            if (isa(newval, Expr))
+                omc.inputlist[value[1]] = [v.args for v in newval.args]
+            else
+                omc.inputlist[value[1]] = value[2]
+            end
+            omc.inputFlag = true
+        else
+            return println(value[1], "  is not a Input")
+        end
+    elseif (isa(name, Array))
+        name = strip_space(name)
+        for var in name
+            value = split(var, "=")
+            if (haskey(omc.inputlist, value[1]))
+                newval = Base.Meta.parse(value[2])
+                if (isa(newval, Expr))
+                    omc.inputlist[value[1]] = [v.args for v in newval.args]
+                else
+                    omc.inputlist[value[1]] = value[2]
+                end
+                # omc.overridevariables[value[1]]=value[2]
+                omc.inputFlag = true
+            else
+                return println(value[1], "  is not a Input")
+            end
+        end
+    end
+end
+
+function strip_space(name)
+    if (isa(name, String))
+        return filter(x -> !isspace(x), name)
+    elseif (isa(name, Array))
+        return [filter(x -> !isspace(x), s) for s in name]
+    end
+end
+
+"""
+Function which returns the working directory of current OMJulia Session
+for each session a temporary directory is created and the simulation results
+are generated
+"""
+function getWorkDirectory(omc)
+    return omc.tempdir
+end
+
+"""
+function which creates the csvinput when user specify new values
+for input variables, this function is used in context with setInputs()
+"""
+function createcsvdata(omc, startTime, stopTime)
+    omc.csvfile = joinpath(omc.tempdir, join([omc.modelname,".csv"]))
+    file = open(omc.csvfile, "w")
+    write(file, join(["time",",",join(keys(omc.inputlist), ","),",","end","\n"]))
+    csvdata = deepcopy(omc.inputlist)
+    value = values(csvdata)
+
+    time = Any[]
+    for val in value
+        if (isa(val, Array))
+            checkflag = "true"
+            for v in val
+                push!(time, v[1])
+            end
+        end
+    end
+
+    if (length(time) == 0)
+        push!(time, startTime)
+        push!(time, stopTime)
+    end
+
+    previousvalue = Dict()
+    for i in sort(time)
+        if (isa(i, SubString{String}) || isa(i, String))
+            write(file, i, ",")
+        else
+            write(file, join(i, ","), ",")
+        end
+        listcount = 1
+        for val in value
+            if (isa(val, Array))
+                newval = val
+                count = 1
+                found = "false"
+                for v in newval
+                    if (i == v[1])
+                        data = eval(v[2])
+                        write(file, join(data, ","), ",")
+                        previousvalue[listcount] = data
+                        deleteat!(newval, count)
+                        found = "true"
+                        break
+                    end
+                    count = count + 1
+                end
+                if (found == "false")
+                    write(file, join(previousvalue[listcount], ","), ",")
+                end
+            end
+
+            if (isa(val, String))
+                if (val == "None")
+                    val = "0"
+                else
+                    val = val
+                end
+                write(file, val, ",")
+                previousvalue[listcount] = val
+            end
+
+            if (isa(val, SubString{String}))
+                if (val == "None")
+                    val = "0"
+                else
+                    val = val
+                end
+                write(file, val, ",")
+                previousvalue[listcount] = val
+            end
+            listcount = listcount + 1
+        end
+        write(file, "0", "\n")
+    end
+    close(file)
+end
+
+"""
+function which returns the linearize model of modelica model,
+The function returns four matrices A,B,C,D
+"""
+function linearize(omc; lintime = nothing, simflags= nothing, verbose=true)
+
+    if (isempty(omc.xmlfile))
+        return println("Linearization cannot be performed as the model is not build, use ModelicaSystem() to build the model first")
+    end
+
+    if (simflags === nothing)
+        simflags="";
+    end
+
+    overridelinearfile = replace(joinpath(omc.tempdir, join([omc.modelname,"_override_linear.txt"])), r"[/\\]+" => "/")
+    # println(overridelinearfile);
+
+    file = open(overridelinearfile, "w")
+    overridelist = false
+    for k in keys(omc.overridevariables)
+        val = join([k,"=",omc.overridevariables[k],"\n"])
+        write(file, val)
+        overridelist = true
+    end
+
+    for t in keys(omc.linearOptions)
+        val = join([t,"=",omc.linearOptions[t], "\n"])
+        write(file, val)
+        overridelist = true
+    end
+
+    close(file)
+
+    if (overridelist == true)
+        overrideFlag = join(["-overrideFile=", overridelinearfile])
+    else
+        overrideFlag = "";
+    end
+
+    if (omc.inputFlag == true)
+        createcsvdata(omc, omc.linearOptions["startTime"], omc.linearOptions["stopTime"])
+        csvinput = join(["-csvInput=", omc.csvfile])
+    else
+        csvinput = "";
+    end
+
+    if (isfile(omc.xmlfile))
+        if (Base.Sys.iswindows())
+            getexefile = replace(joinpath(omc.tempdir, join([omc.modelname,".exe"])), r"[/\\]+" => "/")
+        else
+            getexefile = replace(joinpath(omc.tempdir, omc.modelname), r"[/\\]+" => "/")
+        end
+    else
+        return println("Linearization cannot be performed as : " + omc.xmlfile + " not found, please build the modelica again using ModelicaSystem()")
+    end
+
+    if (lintime !== nothing)
+        linruntime = join(["-l=", lintime])
+    else
+        linruntime = join(["-l=", omc.linearOptions["stopTime"]])
+    end
+
+    finalLinearizationexe = filter!(e -> e ≠ "", [getexefile, linruntime, csvinput, simflags])
+    # println(finalLinearizationexe)
+
+    cd(omc.tempdir)
+    if (Base.Sys.iswindows())
+        installPath = sendExpression(omc, "getInstallationDirectoryPath()")
+        envPath = ENV["PATH"]
+        newPath = "$(envPath);$(installPath)/bin/;$(installPath)/lib/omc;$(installPath)/lib/omc/cpp;$(installPath)/lib/omc/omsicpp"
+        # println("Path: $newPath")
+        withenv("PATH" => newPath) do
+            if verbose
+                run(pipeline(`$finalLinearizationexe`))
+            else
+                run(pipeline(`$finalLinearizationexe`, stdout="log.txt", stderr="error.txt"))
+            end
+        end
+    else
+        if verbose
+            run(pipeline(`$finalLinearizationexe`))
+        else
+            run(pipeline(`$finalLinearizationexe`, stdout="log.txt", stderr="error.txt"))
+        end
+    end
+
+    omc.linearmodelname = "linearized_model"
+    omc.linearfile = joinpath(omc.tempdir, join([omc.linearmodelname,".jl"]))
+
+    # support older openmodelica versions before OpenModelica v1.16.2 where linearize() generates "linear_modelname.mo" file
+    if(!isfile(omc.linearfile))
+        omc.linearmodelname = join(["linear_", omc.modelname])
+        omc.linearfile = joinpath(omc.tempdir, join([omc.linearmodelname, ".jl"]))
+    end
+
+    if (isfile(omc.linearfile))
+        omc.linearFlag = true
+        # this function is called from the generated Julia code linearized_model.jl,
+        # to improve the performance by directly reading the matrices A, B, C and D from the julia code and avoid building the linearized modelica model
+        include("linearized_model.jl")
+        ## to be evaluated at runtime, as Julia expects all functions should be known at the compilation time so efficient assembly code can be generated.
+        result = Base.invokelatest(linearized_model)
+        (n, m, p, x0, u0, A, B, C, D, stateVars, inputVars, outputVars) = result
+        omc.linearstates = stateVars
+        omc.linearinputs = inputVars
+        omc.linearoutputs = outputVars
+        return [A, B, C, D]
+    else
+        errormsg = sendExpression(omc, "getErrorString()")
+        return println("Linearization failed: ","\"" , omc.linearfile,"\"" ," not found \n", errormsg)
+    end
+    cd(omc.currentdir)
+end
+
+"""
+standard getXXX() API
+function which returns the LinearizationOptions
+"""
+function getLinearizationOptions(omc, name=nothing)
+    if (name === nothing)
+        return omc.linearOptions
+    elseif (isa(name, String))
+        return get(omc.linearOptions, name, 0)
+    elseif (isa(name, Array))
+        return [get(omc.linearOptions, x, 0) for x in name]
+    end
+end
+
+"""
+standard getXXX() API
+function which returns the LinearInput variables after the model is linearized
+"""
+function getLinearInputs(omc)
+    if (omc.linearFlag == true)
+        return omc.linearinputs
+    else
+        println("Model is not Linearized")
+    end
+end
+
+"""
+standard getXXX() API
+function which returns the LinearOutput variables after the model is linearized
+"""
+function getLinearOutputs(omc)
+    if (omc.linearFlag == true)
+        return omc.linearoutputs
+    else
+        println("Model is not Linearized")
+    end
+end
+
+"""
+standard getXXX() API
+function which returns the LinearStates variables after the model is linearized
+"""
+function getLinearStates(omc)
+    if (omc.linearFlag == true)
+        return omc.linearstates
+    else
+        println("Model is not Linearized")
+    end
+end
+
+"""
+standard setXXX() API
+function which sets the LinearizationOption values defined by users
+"""
+function setLinearizationOptions(omc, name)
+    if (isa(name, String))
+        name = strip_space(name)
+        value = split(name, "=")
+        if (haskey(omc.linearOptions, value[1]))
+            omc.linearOptions[value[1]] = value[2]
+        else
+            return println(value[1], "  is not a LinearizationOption")
+        end
+    elseif (isa(name, Array))
+        name = strip_space(name)
+        for var in name
+            value = split(var, "=")
+            if (haskey(omc.linearOptions, value[1]))
+                omc.linearOptions[value[1]] = value[2]
+            else
+                return println(value[1], "  is not a LinearizationOption")
+            end
+        end
+    end
+end

--- a/src/omcSession.jl
+++ b/src/omcSession.jl
@@ -121,7 +121,7 @@ mutable struct OMCSession
                     this.omcprocess = open(pipeline(`$ompath $args1 $args2`, stdout="stdout.log", stderr="stderr.log"))
                 end
             end
-            portfile = join(["openmodelica.port.julia.",args3])
+            portfile = join(["openmodelica.port.julia.", randPortSuffix])
         else
             if (Base.Sys.isapple())
                 # add omc to path if not exist

--- a/src/omcSession.jl
+++ b/src/omcSession.jl
@@ -1,0 +1,168 @@
+#=
+This file is part of OpenModelica.
+Copyright (c) 1998-2023, Open Source Modelica Consortium (OSMC),
+c/o Linköpings universitet, Department of Computer and Information Science,
+SE-58183 Linköping, Sweden.
+
+All rights reserved.
+
+THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ACCORDING TO RECIPIENTS CHOICE.
+
+The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+Public License (OSMC-PL) are obtained from OSMC, either from the above
+address, from the URLs: http://www.openmodelica.org or
+http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+distribution. GNU version 3 is obtained from:
+http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+http://www.opensource.org/licenses/BSD-3-Clause.
+
+This program is distributed WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+CONDITIONS OF OSMC-PL.
+=#
+
+"""
+    OMCSession(omc=nothing)
+
+Create new OpenModelica session.
+
+## Arguments
+
+- `omc`: "Path to OpenModelica compiler"
+
+See also [`ModelicaSystem`](@ref).
+"""
+mutable struct OMCSession
+    "Simulation flags, see [Simulation Runtime Flags](https://openmodelica.org/doc/OpenModelicaUsersGuide/latest/simulationflags.html)"
+    simulationFlag
+    inputFlag
+    simulateOptions
+    overridevariables
+    simoptoverride
+    tempdir
+    currentdir
+    resultfile
+    filepath
+    modelname
+    xmlfile
+    csvfile
+    variableFilter
+    quantitieslist
+    parameterlist
+    inputlist
+    outputlist
+    continuouslist
+    linearOptions
+    linearfile
+    linearFlag
+    linearmodelname
+    linearinputs
+    linearoutputs
+    linearstates
+    linearquantitylist
+    context
+    socket
+    omcprocess
+
+    function OMCSession(omc=nothing)::OMCSession
+        this = new()
+        this.overridevariables = Dict()
+        this.simoptoverride = Dict()
+        this.quantitieslist = Any[]
+        this.parameterlist = Dict()
+        this.simulateOptions = Dict()
+        this.inputlist = Dict()
+        this.outputlist = Dict()
+        this.continuouslist = Dict()
+        this.currentdir = pwd()
+        this.filepath = ""
+        this.modelname = ""
+        this.xmlfile = ""
+        this.resultfile = ""
+        this.simulationFlag = false
+        this.inputFlag = false
+        this.csvfile = ""
+        this.variableFilter = ""
+        this.tempdir = ""
+        this.linearfile = ""
+        this.linearFlag = false
+        this.linearmodelname = ""
+        this.linearOptions = Dict("startTime" => "0.0", "stopTime" => "1.0", "stepSize" => "0.002", "tolerance" => "1e-6")
+
+        args1 = "--interactive=zmq"
+        randPortSuffix = Random.randstring(10)
+        args2 = "-z=julia.$(randPortSuffix)"
+        if (Base.Sys.iswindows())
+            if (omc !== nothing)
+                ompath = replace(omc, r"[/\\]+" => "/")
+                dirpath = dirname(dirname(omc))
+                ## create a omc process with OPENMODELICAHOME set to custom directory
+                @info("Setting environment variable OPENMODELICAHOME=\"$dirpath\" for this session.")
+                withenv("OPENMODELICAHOME" => dirpath) do
+                    this.omcprocess = open(pipeline(`$omc $args1 $args2`, stdout="stdout.log", stderr="stderr.log"))
+                end
+            else
+                omhome = ""
+                try
+                    omhome = ENV["OPENMODELICAHOME"]
+                catch Exception
+                    println(Exception, "is not set, Please set the environment Variable")
+                    return
+                end
+                ompath = replace(joinpath(omhome, "bin", "omc.exe"), r"[/\\]+" => "/")
+                # ompath=joinpath(omhome,"bin")
+                ## create a omc process with default OPENMODELICAHOME set in environment variable
+                withenv("OPENMODELICAHOME" => omhome) do
+                    this.omcprocess = open(pipeline(`$ompath $args1 $args2`, stdout="stdout.log", stderr="stderr.log"))
+                end
+            end
+            portfile = join(["openmodelica.port.julia.",args3])
+        else
+            if (Base.Sys.isapple())
+                # add omc to path if not exist
+                ENV["PATH"] = ENV["PATH"] * "/opt/openmodelica/bin"
+                if (omc !== nothing)
+                    this.omcprocess = open(pipeline(`$omc $args1 $args2`, stdout="stdout.log", stderr="stderr.log"))
+                else
+                    this.omcprocess = open(pipeline(`omc $args1 $args2`, stdout="stdout.log", stderr="stderr.log"))
+                end
+            else
+                if (omc !== nothing)
+                    this.omcprocess = open(pipeline(`$omc $args1 $args2`, stdout="stdout.log", stderr="stderr.log"))
+                else
+                    this.omcprocess = open(pipeline(`omc $args1 $args2`, stdout="stdout.log", stderr="stderr.log"))
+                end
+            end
+            portfile = join(["openmodelica.", ENV["USER"],".port.julia.", randPortSuffix])
+        end
+        fullpath = joinpath(tempdir(), portfile)
+        @info("Path to zmq file=\"$fullpath\"")
+        ## Try to find better approach if possible, as sleep does not work properly across different platform
+        tries = 0
+        while tries < 100 && !isfile(fullpath)
+            sleep(0.02)
+            tries += 1
+        end
+        # Catch omc error
+        if process_exited(this.omcprocess) && this.omcprocess.exitcode != 0
+            throw(OMCError(this.omcprocess.cmd, "stdout.log", "stderr.log"))
+        else
+            @debug read(e.stdout_file, String)
+            @debug read(e.stderr_file, String)
+            rm.(["stdout.log", "stderr.log"], force=true)
+        end
+        if tries >= 100
+            throw(TimeoutError("ZMQ server port file \"$fullpath\" not created yet."))
+        end
+        filedata = read(fullpath, String)
+        this.context = ZMQ.Context()
+        this.socket = ZMQ.Socket(this.context, REQ)
+        ZMQ.connect(this.socket, filedata)
+        return this
+    end
+end


### PR DESCRIPTION
@arun3688 I translated most of the [User's Guide](https://openmodelica.org/doc/OpenModelicaUsersGuide/latest/omjulia.html) documentation into a OMJulia documentation using Documenter.jl.

It's still rough and a lot of functions are not using the "Julia style" of documentation, see https://docs.julialang.org/en/v1/manual/documentation/.

Also many examples are broken (maybe the User's guide was outdated or the function was never used).

Can you update the docstrings of the modelicaSystem functions?

To build and host locally:
```julia
using Pkg; Pkg.activate("docs/"); Pkg.resolve()
using OMJulia, LiveServer
servedocs()
```