### PR TITLE
fix overrideFile args in linearize()

### DIFF
--- a/src/OMJulia.jl
+++ b/src/OMJulia.jl
@@ -1107,7 +1107,7 @@ function linearize(omc; lintime = nothing, simflags= nothing, verbose=true)
         linruntime = join(["-l=", omc.linearOptions["stopTime"]])
     end
 
-    finalLinearizationexe = filter!(e -> e ≠ "", [getexefile, linruntime, csvinput, simflags])
+    finalLinearizationexe = filter!(e -> e ≠ "", [getexefile, linruntime, overrideFlag, csvinput, simflags])
     # println(finalLinearizationexe)
 
     cd(omc.tempdir)


### PR DESCRIPTION
### Purpose

This PR fixes the `overridFile`  args in `linearization` command