### PR TITLE
Adding quit function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,10 +16,3 @@ DataStructures = "0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16.1, 0.17, 0.18"
 LightXML = "0.8, 0.9"
 ZMQ = "1"
 julia = "1.9"
-
-[extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
-
-[targets]
-test = ["Test", "SafeTestsets"]

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ julia> import Pkg; Pkg.add("OMJulia")
 
 ```julia
 julia> using OMJulia
-julia> using OMJulia: sendExpression
-julia> omc=OMJulia.OMCSession()
+julia> omc = OMJulia.OMCSession()
 julia> sendExpression(omc, "getVersion()")
 "OpenModelica v1.21.0-dev-185-g9d983b8e35 (64-bit)"
 julia> sendExpression(omc, "model a end a;")
@@ -47,7 +46,7 @@ Dict{String,Any} with 10 entries:
   "resultFile"        => "PATH/TO/Modelica.Electrical.Analog.Examples.CauerLowPassAnalog_res.mat"
   "timeSimCode"       => 0.0409317
   "timeBackend"       => 0.140713
-julia> OMJulia.sendExpression(omc, "quit()",parsed=false)
+julia> OMJulia.quit(omc)
 "quit requested, shutting server down\n"
 ```
 

--- a/docs/src/modelicaSystem.md
+++ b/docs/src/modelicaSystem.md
@@ -8,6 +8,7 @@ ModelicaSystem
 
 ```@docs
 OMJulia.OMCSession
+OMJulia.quit
 ```
 
 Let us see the usage of ModelicaSystem with the help of Modelica model `ModSeborgCSTRorg`
@@ -83,12 +84,12 @@ getWorkDirectory
 getWorkDirectory(mod)
 ```
 
-
 ## Build Model
 
 ```@docs
 buildModel
 ```
+
 In case the Modelica model needs to be updated or additional simulation flags needs to be
 set using [`sendExpression`](@ref) The [`buildModel`](@ref) API can be used after
 [`ModelicaSystem`](@ref).
@@ -97,6 +98,7 @@ set using [`sendExpression`](@ref) The [`buildModel`](@ref) API can be used afte
 buildModel(omc)
 buildModel(omc, variableFilter="a|T")
 ```
+
 ## Get Methods
 
 ```@docs
@@ -266,4 +268,5 @@ sensitivity
 
 ```@repl ModSeborgCSTRorg-example
 (Sn, Sa) = sensitivity(mod, ["UA","EdR"], ["T","cA"], [1e-2,1e-4])
+OMJulia.quit(mod) # hide
 ```

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -59,6 +59,7 @@ plt = plot(df,
 
 ```@example ModelicaSystem-example
 PlotlyDocumenter.to_documenter(plt) # hide
+OMJulia.quit(mod) # hide
 ```
 
 ## Scripting API with sendExpression
@@ -77,4 +78,5 @@ mkpath(omcWorkDoir)                                 # hide
 sendExpression(omc, "cd(\"$(omcWorkDoir)\")")       # hide
 sendExpression(omc, "model a Real s; equation s=sin(10*time); end a;")
 sendExpression(omc, "simulate(a)")
+OMJulia.quit(omc)
 ```

--- a/docs/src/sendExpression.md
+++ b/docs/src/sendExpression.md
@@ -12,6 +12,7 @@ sendExpression
 
 ```@repl
 using OMJulia       # hide
-omc = OMCSession()  # hide
+omc = OMJulia.OMCSession()  # hide
 version = OMJulia.sendExpression(omc, "getVersion()")
+OMJulia.quit(omc)
 ```

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/modelicaSystemTest.jl
+++ b/test/modelicaSystemTest.jl
@@ -43,4 +43,5 @@ import OMJulia
     OMJulia.simulate(mod,
                      resultfile = resultfile)
     @test isfile(resultfile)
+    OMJulia.quit(mod)
 end

--- a/test/omcTest.jl
+++ b/test/omcTest.jl
@@ -56,7 +56,7 @@ import OMJulia
             @test occursin("The simulation finished successfully.", res["messages"])
 
             @test 3 == OMJulia.sendExpression(omc, "1+2")
-            # TODO: sendExpression(quit()) and kill(omc.omcprocess) get stuck on Ubuntu
+            OMJulia.quit(omc)
         finally
             cd(oldwd)
         end
@@ -90,7 +90,8 @@ import OMJulia
             res = OMJulia.sendExpression(omc2, "simulate(Modelica.Blocks.Examples.PID_Controller)")
             @test isfile(joinpath(@__DIR__, "test-omc2", "Modelica.Blocks.Examples.PID_Controller_res.mat"))
 
-            # TODO: sendExpression(quit()) and kill(omc.omcprocess) get stuck on Ubuntu
+            OMJulia.quit(omc1)
+            OMJulia.quit(omc2)
         finally
             cd(oldwd)
         end


### PR DESCRIPTION
## Related issues

Fixes https://github.com/OpenModelica/OMJulia.jl/issues/96, fixes https://github.com/OpenModelica/OMJulia.jl/issues/32.

## Changes

  - quit function: - Send quit() to omc. - Kill omc process if not responding fast enough.
  -  Register finalizer on omc process to kill when OMCSession is no longer reachable