### PR TITLE
Updating documentation

### DIFF
--- a/docs/src/modelicaSystem.md
+++ b/docs/src/modelicaSystem.md
@@ -1,5 +1,6 @@
 # Advanced API
 
+A Julia style scripting API that handles low level API calls.
 ## ModelicaSystem
 
 ```@docs
@@ -11,7 +12,9 @@ OMJulia.OMCSession
 OMJulia.quit
 ```
 
-Let us see the usage of ModelicaSystem with the help of Modelica model `ModSeborgCSTRorg`
+### Example 
+Let us see the usage of [`ModelicaSystem`](@ref) with the help of Modelica model
+`ModSeborgCSTRorg`
 
 ```modelica
 model ModSeborgCSTRorg
@@ -59,7 +62,7 @@ equation
   y_T = T;
 end ModSeborgCSTRorg
 ```
-### Example
+
 ```@repl ModSeborgCSTRorg-example
 using OMJulia
 mod = OMJulia.OMCSession()
@@ -73,13 +76,14 @@ ModelicaSystem(mod,
 
 ## WorkDirectory
 
-For each OMJulia session a temporary work directory is created and the results are
-published in that working directory.
+For each [`OMJulia.OMCSession`](@ref) session a temporary work directory is created and
+the results are published in that working directory.
 In order to get the work directory use [`getWorkDirectory`](@ref).
 
 ```@docs
 getWorkDirectory
 ```
+
 ```@repl ModSeborgCSTRorg-example
 getWorkDirectory(mod)
 ```
@@ -112,12 +116,7 @@ getSimulationOptions
 getSolutions
 ```
 
-Three calling possibilities are accepted using getXXX() where "XXX" can be any of the above functions (eg:) getParameters().
-1. getXXX() without input argument, returns a dictionary with names as keys and values as values.
-2. getXXX(S), where S is a string of names.
-3. getXXX(["S1","S2"]) where S1 and S1 are array of string elements
-
-### Examples of using Get Methods
+### Examples
 
 ```@repl ModSeborgCSTRorg-example
 getQuantities(mod)
@@ -146,6 +145,7 @@ getSimulationOptions(mod)
 getSimulationOptions(mod, ["stepSize","tolerance"])
 ```
 ### Reading Simulation Results
+
 To read the simulation results, we need to simulate the model first and use the getSolution() API to read the results
 
 ```@repl ModSeborgCSTRorg-example
@@ -175,10 +175,6 @@ setInputs
 setParameters
 setSimulationOptions
 ```
-
-Two setting possibilities are accepted using setXXXs(),where "XXX" can be any of above functions.
-1.setXXX("Name=value") string of keyword assignments
-2.setXXX(["Name1=value1","Name2=value2","Name3=value3"]) array of string of keyword assignments
 
 ### Examples
 

--- a/docs/src/modelicaSystem.md
+++ b/docs/src/modelicaSystem.md
@@ -12,7 +12,7 @@ OMJulia.OMCSession
 OMJulia.quit
 ```
 
-### Example 
+### Example
 Let us see the usage of [`ModelicaSystem`](@ref) with the help of Modelica model
 `ModSeborgCSTRorg`
 

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -55,11 +55,12 @@ plt = plot(df,
            x=:time, y=:h,
            mode="lines",
            Layout(title="Bouncing Ball", height = 700))
+
+OMJulia.quit(mod)
 ```
 
 ```@example ModelicaSystem-example
 PlotlyDocumenter.to_documenter(plt) # hide
-OMJulia.quit(mod) # hide
 ```
 
 ## Scripting API with sendExpression

--- a/src/modelicaSystem.jl
+++ b/src/modelicaSystem.jl
@@ -293,7 +293,7 @@ Return list of all variables parsed from xml file.
 ## Arguments
 
 - `omc::OMCSession`:        OpenModelica compiler session.
-- `name::Union{<:AbstractString, Array{<:AbstractString,1}, Nothing}`: Name(s) of variables to read from xml file.
+- `name::Union{<:AbstractString, Array{<:AbstractString,1}, Nothing}`: Names of variables to read from xml file.
                                                                        If nothing is provided read all variables.
 
 See also [`showQuantities`](@ref).
@@ -328,7 +328,7 @@ Return `DataFrame` of all variables parsed from xml file.
 ## Arguments
 
 - `omc::OMCSession`:        OpenModelica compiler session.
-- `name::Union{<:AbstractString, Array{<:AbstractString,1}, Nothing}`:     Name(s) of variables to read from xml file.
+- `name::Union{<:AbstractString, Array{<:AbstractString,1}, Nothing}`:     Names of variables to read from xml file.
                                                                        If nothing is provided read all variables.
 
 See also [`getQuantities`](@ref).
@@ -367,7 +367,7 @@ Return parameter variables parsed from xml file.
 ## Arguments
 
 - `omc::OMCSession`:        OpenModelica compiler session.
-- `name::Union{<:AbstractString, Array{<:AbstractString,1}, Nothing}`:     Name(s) of parameters to read from xml file.
+- `name::Union{<:AbstractString, Array{<:AbstractString,1}, Nothing}`:     Names of parameters to read from xml file.
                                                                        If nothing is provided read all parameters.
 """
 function getParameters(omc::OMCSession, name::Union{<:AbstractString, Array{<:AbstractString,1}, Nothing} = nothing)
@@ -388,7 +388,7 @@ Return SimulationOption variables parsed from xml file.
 ## Arguments
 
 - `omc::OMCSession`:        OpenModelica compiler session.
-- `name::Union{<:AbstractString, Array{<:AbstractString,1}, Nothing}`:     Name(s) of parameters to read from xml file.
+- `name::Union{<:AbstractString, Array{<:AbstractString,1}, Nothing}`:     Names of parameters to read from xml file.
                                                                        If nothing is provided read all parameters.
 """
 function getSimulationOptions(omc::OMCSession, name::Union{<:AbstractString, Array{<:AbstractString,1}, Nothing} = nothing)
@@ -409,7 +409,7 @@ Return continuous variables parsed from xml file.
 ## Arguments
 
 - `omc::OMCSession`:        OpenModelica compiler session.
-- `name::Union{<:AbstractString, Array{<:AbstractString,1}, Nothing}`:  Name(s) of continuous variables to read from xml file.
+- `name::Union{<:AbstractString, Array{<:AbstractString,1}, Nothing}`:  Names of continuous variables to read from xml file.
                                                                         If nothing is provided read all continuous variables.
 """
 function getContinuous(omc::OMCSession, name::Union{<:AbstractString, Array{<:AbstractString,1}, Nothing} = nothing)
@@ -471,7 +471,7 @@ If input variables have no start value the returned value is `\"None\"`.
 ## Arguments
 
 - `omc::OMCSession`:        OpenModelica compiler session.
-- `name::Union{<:AbstractString, Array{<:AbstractString,1}, Nothing}`:     Name(s) of input variables to read from xml file.
+- `name::Union{<:AbstractString, Array{<:AbstractString,1}, Nothing}`:     Names of input variables to read from xml file.
                                                                        If nothing is provided read all input variables.
 """
 function getInputs(omc::OMCSession, name::Union{<:AbstractString, Array{<:AbstractString,1}, Nothing} = nothing)
@@ -493,7 +493,7 @@ If output variables have no start value the returned value is `\"None\"`.
 ## Arguments
 
 - `omc::OMCSession`:        OpenModelica compiler session.
-- `name::Union{<:AbstractString, Array{<:AbstractString,1}, Nothing}`:  Name(s) of output variables to read from xml file.
+- `name::Union{<:AbstractString, Array{<:AbstractString,1}, Nothing}`:  Names of output variables to read from xml file.
                                                                         If nothing is provided read all output variables.
 """
 function getOutputs(omc::OMCSession, name::Union{<:AbstractString, Array{<:AbstractString,1}, Nothing}=nothing)
@@ -752,7 +752,7 @@ Read result file and return simulation results
 ## Arguments
 
 - `omc::OMCSession`:        OpenModelica compiler session.
-- `name::Union{<:AbstractString, Array{<:AbstractString,1}, Nothing}`:  Name(s) of variables to read from result file.
+- `name::Union{<:AbstractString, Array{<:AbstractString,1}, Nothing}`:  Names of variables to read from result file.
                                                                         If nothing is provided read all variables.
 
 ## Keyword Arguments
@@ -1207,7 +1207,7 @@ Return linearization options.
 ## Arguments
 
 - `omc::OMCSession`:        OpenModelica compiler session.
-- `name::Union{<:AbstractString, Array{<:AbstractString,1}, Nothing}`: Name(s) of linearization options.
+- `name::Union{<:AbstractString, Array{<:AbstractString,1}, Nothing}`: Names of linearization options.
                                                                        If nothing is provided return all linearization options.
 """
 function getLinearizationOptions(omc::OMCSession,

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -46,7 +46,7 @@ end
 function parseSequence(tokens, last)
   res = []
   tok = popfirst!(tokens)
-  if (tok == last)
+  if tok == last
     return res
   end
   push!(res, parseOM(tok, tokens))
@@ -112,7 +112,7 @@ function parseOM(t::Record, tokens)
 end
 
 function parseOM(tokens::AbstractArray{Any,1})
-  if (length(tokens)==0)
+  if length(tokens)==0
     return nothing
   end
   t = popfirst!(tokens)

--- a/src/sendExpression.jl
+++ b/src/sendExpression.jl
@@ -72,14 +72,14 @@ OMJulia.sendExpression(omc, "getVersion()")
 ```
 """
 function sendExpression(omc::OMCSession, expr::String; parsed=true)
-    if (!process_running(omc.omcprocess))
+    if !process_running(omc.zmqSession.omcprocess)
         return error("Process Exited, No connection with OMC. Create a new instance of OMCSession")
     end
 
     @debug "sending expression: $(expr)"
-    ZMQ.Sockets.send(omc.socket, expr)
+    ZMQ.Sockets.send(omc.zmqSession.socket, expr)
     @debug "Receiving message from ZMQ socket"
-    message = ZMQ.Sockets.recv(omc.socket)
+    message = ZMQ.Sockets.recv(omc.zmqSession.socket)
     @debug "Recieved message"
     if parsed
         return Parser.parseOM(unsafe_string(message))


### PR DESCRIPTION
Some improvements for the documentation.

Docstrings are now helpfull without the online documentation:

Old:

```julia
help?> OMJulia.showQuantities
  standard getXXX() API function same as getQuantities(), but returns all the variables as table
```

New:

```julia
help?> OMJulia.showQuantities
  showQuantities(omc, name=nothing)

  Return DataFrame of all variables parsed from xml file.

  Arguments
  ===========

    •  omc::OMCSession: OpenModelica compiler session.

    •  name::Union{<:AbstractString, Array{<:AbstractString,1}, Nothing}: Name(s) of variables to read from xml file. If nothing is provided read all variables.

  See also getQuantities.
```

## Related Issues

Fixes https://github.com/OpenModelica/OMJulia.jl/issues/87, fixes https://github.com/OpenModelica/OMJulia.jl/issues/85.

## Changes

  - Adding types to function interfaces
  - Adding types to structs
  - Refactoring OMCSession into multiple structs
  - Document get and set methods
  - Simplifying if statements, removing brackets
  - Changing prints to @error or @info