### PR TITLE
Make quickstart examples executable

### DIFF
--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -368,7 +368,7 @@ version = "1.2.0"
 deps = ["DataFrames", "DataStructures", "LightXML", "Random", "ZMQ"]
 path = ".."
 uuid = "0f4fe800-344e-11e9-2949-fb537ad918e1"
-version = "0.2.1"
+version = "0.2.2"
 
 [[deps.Observables]]
 git-tree-sha1 = "6862738f9796b3edc1c09d0890afce4eca9e7e93"

--- a/src/sendExpression.jl
+++ b/src/sendExpression.jl
@@ -49,8 +49,8 @@ for a complete list of all functions.
     ```
 
 !!! warn
-    On Windows path separation symbol `\\` needs to be escaped and doubled  `\\\\` to
-    prevent warnings.
+    On Windows path separation symbol `\\` needs to be escaped `\\\\`
+    or replaced to Unix style path `/` to prevent warnings.
 
     ```modelica
     loadFile("C:\\\\path\\\\to\\\\M.mo")


### PR DESCRIPTION
The examples from Quickstart can now be copy-pasted and will simply work:

```julia
julia> using OMJulia
julia> using CSV, DataFrames, PlotlyJS
julia> mod = OMJulia.OMCSession();

julia> installDir = sendExpression(mod, "getInstallationDirectoryPath()")
julia> bouncingBallFile = joinpath(installDir, "share", "doc", "omc", "testmodels", "BouncingBall.mo")

julia> ModelicaSystem(mod,
                      bouncingBallFile,
                      "BouncingBall")

julia> simulate(mod,
                resultfile = "BouncingBall_ref.csv",
                simflags   = "-override=outputFormat=csv,stopTime=3")

julia> resultfile = joinpath(getWorkDirectory(mod), "BouncingBall_ref.csv")

julia> df = DataFrame(CSV.File(resultfile));
julia> plt = plot(df,
                  x=:time, y=:h,
                  mode="lines",
                  Layout(title="Bouncing Ball", height = 700))

julia> OMJulia.quit(mod)
```