### PR TITLE
allow modelicaSystem() to directly load MSL without filename

### DIFF
--- a/src/modelicaSystem.jl
+++ b/src/modelicaSystem.jl
@@ -136,10 +136,14 @@ ModelicaSystem(mod, modelname="Modelica.Electrical.Analog.Examples.CauerLowPassA
 See also [`OMCSession()`](@ref).
 """
 function ModelicaSystem(omc::OMCSession;
-    modelname::AbstractString,
+    modelname::AbstractString=nothing,
     library::Union{<:AbstractString,Tuple{<:AbstractString,<:AbstractString},Array{<:AbstractString},Array{Tuple{<:AbstractString,<:AbstractString}},Nothing}=nothing,
     commandLineOptions::Union{<:AbstractString,Nothing}=nothing,
     variableFilter::Union{<:AbstractString,Nothing}=nothing)
+
+    if isnothing(modelname)
+        return println("\"ModelicaSystem()\" constructor requires modelname")
+    end
 
     ## check for commandLineOptions
     setCommandLineOptions(omc, commandLineOptions)

--- a/src/modelicaSystem.jl
+++ b/src/modelicaSystem.jl
@@ -27,16 +27,16 @@ CONDITIONS OF OSMC-PL.
 =#
 
 """
-    ModelicaSystem(omc, filename, modelname, library=nothing;
+    ModelicaSystem(omc, fileName, modelName, library=nothing;
                    commandLineOptions=nothing, variableFilter=nothing)
 
-Set command line options for OMCSession and build model `modelname` to prepare for a simulation.
+Set command line options for OMCSession and build model `modelName` to prepare for a simulation.
 
 ## Arguments
 
 - `omc`:       OpenModelica compiler session, see `OMCSession()`.
-- `filename`:  Path to Modelica file.
-- `modelname`: Name of Modelica model to build, including namespace if the
+- `fileName`:  Path to Modelica file.
+- `modelName`: Name of Modelica model to build, including namespace if the
                model is wrappen within a Modelica package.
 - `library`:   List of dependent libraries or Modelica files.
                This argument can be passed as string (e.g. `"Modelica"`)
@@ -69,8 +69,8 @@ ModelicaSystem(mod, "BouncingBall.mo", "BouncingBall", ["Modelica", "SystemDynam
 See also [`OMCSession()`](@ref).
 """
 function ModelicaSystem(omc::OMCSession,
-                        filename::AbstractString,
-                        modelname::AbstractString,
+                        fileName::AbstractString = nothing,
+                        modelName::AbstractString = nothing,
                         library::Union{<:AbstractString, Tuple{<:AbstractString, <:AbstractString}, Array{<:AbstractString}, Array{Tuple{<:AbstractString, <:AbstractString}}, Nothing} = nothing;
                         commandLineOptions::Union{<:AbstractString, Nothing} = nothing,
                         variableFilter::Union{<:AbstractString, Nothing} = nothing)
@@ -84,12 +84,12 @@ function ModelicaSystem(omc::OMCSession,
     sendExpression(omc, "setCommandLineOptions(\"--linearizationDumpLanguage=julia\")")
     sendExpression(omc, "setCommandLineOptions(\"--generateSymbolicLinearization\")")
 
-    omc.filepath = filename
-    omc.modelname = modelname
+    omc.filepath = fileName
+    omc.modelname = modelName
     omc.variableFilter = variableFilter
 
     #loadFile and set temporary directory
-    loadFile(omc, filename)
+    loadFile(omc, fileName)
 
     #set temp directory for each modelica session
     setTempDirectory(omc)
@@ -103,7 +103,7 @@ end
 
 
 """
-    ModelicaSystem(omc; modelname, library=nothing,
+    ModelicaSystem(omc; modelName, library=nothing,
                    commandLineOptions=nothing, variableFilter=nothing)
 
 Set command line options for OMCSession and build model `modelname` to prepare for a simulation.
@@ -114,7 +114,7 @@ Set command line options for OMCSession and build model `modelname` to prepare f
 
 ## Keyword Arguments
 
-- `modelname`: Name of Modelica model to build, including namespace if the
+- `modelName`: Name of Modelica model to build, including namespace if the
                model is wrappen within a Modelica package.
 - `library`:   List of dependent libraries or Modelica files.
                This argument can be passed as string (e.g. `"Modelica"`)
@@ -131,18 +131,18 @@ Set command line options for OMCSession and build model `modelname` to prepare f
 ```
 using OMJulia
 mod = OMJulia.OMCSession()
-ModelicaSystem(mod, modelname="Modelica.Electrical.Analog.Examples.CauerLowPassAnalog", library="Modelica")
+ModelicaSystem(mod, modelName="Modelica.Electrical.Analog.Examples.CauerLowPassAnalog", library="Modelica")
 ```
 See also [`OMCSession()`](@ref).
 """
 function ModelicaSystem(omc::OMCSession;
-    modelname::AbstractString=nothing,
+    modelName::AbstractString=nothing,
     library::Union{<:AbstractString,Tuple{<:AbstractString,<:AbstractString},Array{<:AbstractString},Array{Tuple{<:AbstractString,<:AbstractString}},Nothing}=nothing,
     commandLineOptions::Union{<:AbstractString,Nothing}=nothing,
     variableFilter::Union{<:AbstractString,Nothing}=nothing)
 
-    if isnothing(modelname)
-        return println("\"ModelicaSystem()\" constructor requires modelname")
+    if isnothing(modelName)
+        return println("\"ModelicaSystem()\" constructor requires modelName")
     end
 
     ## check for commandLineOptions
@@ -154,7 +154,7 @@ function ModelicaSystem(omc::OMCSession;
     sendExpression(omc, "setCommandLineOptions(\"--linearizationDumpLanguage=julia\")")
     sendExpression(omc, "setCommandLineOptions(\"--generateSymbolicLinearization\")")
 
-    omc.modelname = modelname
+    omc.modelname = modelName
     omc.variableFilter = variableFilter
 
     #set temp directory for each modelica session

--- a/test/testFMIExport.jl
+++ b/test/testFMIExport.jl
@@ -35,11 +35,11 @@ import OMJulia
     mkpath(workdir)
 
     mod = OMJulia.OMCSession()
-    OMJulia.ModelicaSystem(mod, modelname="Modelica.Electrical.Analog.Examples.CauerLowPassAnalog", library="Modelica")
+    OMJulia.ModelicaSystem(mod, modelName="Modelica.Electrical.Analog.Examples.CauerLowPassAnalog", library="Modelica")
     fmu1 = OMJulia.convertMo2FMU(mod)
     @test isfile(fmu1)
 
-    OMJulia.ModelicaSystem(mod, modelname="Modelica.Fluid.Examples.DrumBoiler.DrumBoiler", library="Modelica")
+    OMJulia.ModelicaSystem(mod, modelName="Modelica.Fluid.Examples.DrumBoiler.DrumBoiler", library="Modelica")
     fmu2 = OMJulia.convertMo2FMU(mod)
     @test isfile(fmu2)
 

--- a/test/testFMIExport.jl
+++ b/test/testFMIExport.jl
@@ -1,0 +1,47 @@
+#=
+This file is part of OpenModelica.
+Copyright (c) 1998-2023, Open Source Modelica Consortium (OSMC),
+c/o Linköpings universitet, Department of Computer and Information Science,
+SE-58183 Linköping, Sweden.
+
+All rights reserved.
+
+THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ACCORDING TO RECIPIENTS CHOICE.
+
+The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+Public License (OSMC-PL) are obtained from OSMC, either from the above
+address, from the URLs: http://www.openmodelica.org or
+http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+distribution. GNU version 3 is obtained from:
+http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+http://www.opensource.org/licenses/BSD-3-Clause.
+
+This program is distributed WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+CONDITIONS OF OSMC-PL.
+=#
+
+using Test
+import OMJulia
+
+@testset "testFMIExport" begin
+    workdir = abspath(joinpath(@__DIR__, "test_fmi_export"))
+    rm(workdir, recursive=true, force=true)
+    mkpath(workdir)
+
+    mod = OMJulia.OMCSession()
+    OMJulia.ModelicaSystem(mod, modelname="Modelica.Electrical.Analog.Examples.CauerLowPassAnalog", library="Modelica")
+    fmu1 = OMJulia.convertMo2FMU(mod)
+    @test isfile(fmu1)
+
+    OMJulia.ModelicaSystem(mod, modelname="Modelica.Fluid.Examples.DrumBoiler.DrumBoiler", library="Modelica")
+    fmu2 = OMJulia.convertMo2FMU(mod)
+    @test isfile(fmu2)
+
+    OMJulia.quit(mod)
+end


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/11414

### Purpose
This PR implements `ModelicaSystem()` constructor to directly load `MSL` without using the filename by overloading the `ModelicaSystem() ` constructor to support adding tests from MSL 