### PR TITLE
Pass each simulation flag as its own argument

### DIFF
--- a/src/modelicaSystem.jl
+++ b/src/modelicaSystem.jl
@@ -706,7 +706,11 @@ function simulate(omc::OMCSession;
                     # run(pipeline(`$getexefile $overridevar`,stdout="log.txt",stderr="error.txt"))
                 end
                 # remove empty args in cmd objects
-                cmd = filter!(e -> e ≠ "", [getexefile,overridevar,csvinput,r,simflags])
+                # `simflags` is a single string that may hold several flags; split it so
+                # each reaches the executable as its own argument rather than one
+                # quoted blob. See https://github.com/OpenModelica/OMJulia.jl/issues/133
+                cmd = filter!(e -> e ≠ "", [getexefile, overridevar, csvinput, r])
+                append!(cmd, String.(split(simflags)))
                 # println(cmd)
                 if Sys.iswindows()
                     installPath = sendExpression(omc, "getInstallationDirectoryPath()")
@@ -1277,7 +1281,9 @@ function linearize(omc::OMCSession; lintime = nothing, simflags= nothing, verbos
         linruntime = join(["-l=", omc.linearization.linearOptions["stopTime"]])
     end
 
-    finalLinearizationexe = filter!(e -> e ≠ "", [getexefile, linruntime, overrideFlag, csvinput, simflags])
+    # Split `simflags` so each flag is its own argument; see issue #133.
+    finalLinearizationexe = filter!(e -> e ≠ "", [getexefile, linruntime, overrideFlag, csvinput])
+    append!(finalLinearizationexe, String.(split(simflags)))
     # println(finalLinearizationexe)
 
     # `cd` into tempdir to run the simulation executable, and restore the

--- a/test/modelicaSystemTest.jl
+++ b/test/modelicaSystemTest.jl
@@ -80,3 +80,37 @@ end
         OMJulia.quit(mod)
     end
 end
+
+# `simflags` is one string that may carry several flags. Each has to reach the
+# executable as its own argument -- passing the whole string as a single argv
+# entry makes the runtime reject it as one unrecognized option.
+# See https://github.com/OpenModelica/OMJulia.jl/issues/133
+@testset "Multiple simulation flags" begin
+    workdir = abspath(joinpath(@__DIR__, "test-simflags"))
+    rm(workdir, recursive=true, force=true)
+    mkpath(workdir)
+
+    mod = OMJulia.OMCSession()
+    try
+        OMJulia.ModelicaSystem(mod,
+                               joinpath(@__DIR__, "..", "docs", "testmodels", "ModSeborgCSTRorg.mo"),
+                               "ModSeborgCSTRorg")
+
+        # One flag worked before; several did not.
+        OMJulia.simulate(mod, resultfile = joinpath(workdir, "one.mat"),
+                         simflags = "-s=euler")
+        @test isfile(joinpath(workdir, "one.mat"))
+
+        OMJulia.simulate(mod, resultfile = joinpath(workdir, "two.mat"),
+                         simflags = "-s=euler -emit_protected")
+        @test isfile(joinpath(workdir, "two.mat"))
+
+        # An empty or absent value must still mean "no flags".
+        OMJulia.simulate(mod, resultfile = joinpath(workdir, "none.mat"))
+        @test isfile(joinpath(workdir, "none.mat"))
+
+        @test OMJulia.linearize(mod, simflags = "-s=euler -emit_protected") isa Vector
+    finally
+        OMJulia.quit(mod)
+    end
+end


### PR DESCRIPTION
Closes #133.

@AIAfernandezc read this correctly: both flags are passed as a single argument.

`simflags` is one string that may carry several flags, but it went into the
argument vector as one element, so the whole thing reached the executable as a
single argv entry:

```
Process(`.../Simple '-s=euler -newtonMaxStepFactor=0.1'`, ProcessExited(255))
warning | unrecognized option -s euler -newtonMaxStepFactor=0.1
```

One flag worked, two never did — in `simulate` and `linearize` both. The
docstring has advertised the broken form since it was written:
`simflags="-noEmitEvent -override=e=0.3,g=9.3"`.

## Fix

Split on whitespace at both call sites. `split` drops empty fields, so an empty
string or an absent value still means no flags.

## Verification

Confirmed at the exec level against omc 1.26 that nothing but argument splitting
is involved:

| passed to the executable | result |
|---|---|
| `["-s=euler"]` | runs |
| `["-emit_protected"]` | runs |
| `["-s=euler", "-emit_protected"]` | runs |
| `["-s=euler -emit_protected"]` | rejected |

Through the API after the fix, `simulate` and `linearize` both accept one flag,
several flags, and none. The new testset covers all three plus `linearize`, and
errors against the unfixed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)