### PR TITLE
Fail instead of hanging when omc stops answering

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OMJulia"
 uuid = "0f4fe800-344e-11e9-2949-fb537ad918e1"
 authors = ["Martin Sjölund <martin.sjolund@liu.se>", "Arunkumar Palanisamy <arunkumar.palanisamy@liu.se>"]
-version = "0.3.4"
+version = "0.4.0"
 
 [deps]
 Automa = "67c07d97-cdcb-5c2c-af73-a7f9c32a568b"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -8,5 +8,5 @@ PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a"
 
 [compat]
 Documenter = "^0.27"
-OMJulia = "^0.3.0"
+OMJulia = "^0.4.0"
 PlotlyJS = "^0.18.13"

--- a/src/modelicaSystem.jl
+++ b/src/modelicaSystem.jl
@@ -776,7 +776,7 @@ function convertMo2FMU(omc; version::String = "2.0", fmuType::String = "me_cs", 
 
     ## check again for the length if unable to reduce
     if length(fileNamePrefix) > 50
-        return println("length of fileNamePrefix", fileNamePrefix,   "is too long ", length(fileNamePrefix), "fileNamePrefix prefix should be less than 50 characters")
+        error("fileNamePrefix \"$(fileNamePrefix)\" is $(length(fileNamePrefix)) characters; it must be shorter than 50.")
     end
 
     exp = join(["buildModelFMU(", omc.modelname, ", version=", API.modelicaString(version), ", fmuType=", API.modelicaString(fmuType), ", fileNamePrefix=", API.modelicaString(fileNamePrefix), ", includeResources=", includeResources, ")"])
@@ -784,7 +784,7 @@ function convertMo2FMU(omc; version::String = "2.0", fmuType::String = "me_cs", 
     fmu = sendExpression(omc, exp)
 
     if !isfile(fmu)
-        return println(sendExpression(omc, "getErrorString()"))
+        error("Failed to build FMU for $(omc.modelname):\n$(sendExpression(omc, "getErrorString()"))")
     end
 
     return fmu
@@ -795,7 +795,7 @@ function which converts FMU to modelicamodel
 """
 function convertFmu2Mo(omc::OMCSession, fmupath)
     if !isfile(fmupath)
-        return println(fmupath, " does not exist")
+        error("\"$(fmupath)\" does not exist")
     end
 
     fmupath = replace(fmupath, r"[/\\]+" => "/")
@@ -803,7 +803,7 @@ function convertFmu2Mo(omc::OMCSession, fmupath)
     filename = sendExpression(omc, "importFMU(\"" * fmupath * "\")")
 
     if !isfile(filename)
-        return println(sendExpression(omc, "getErrorString()"))
+        error("Failed to import FMU \"$(fmupath)\":\n$(sendExpression(omc, "getErrorString()"))")
     end
 
     return filename

--- a/src/omcSession.jl
+++ b/src/omcSession.jl
@@ -82,7 +82,11 @@ mutable struct ZMQSession
 
     function ZMQSession(omc::Union{String, Nothing}=nothing)::ZMQSession
         args1 = "--interactive=zmq"
-        randPortSuffix = Random.randstring(10)
+        # Draw from the OS, not the global RNG. `@testset` reseeds the global
+        # RNG identically for every testset, so `randstring(10)` returns the
+        # same string in each one -- every session created first inside a
+        # testset would then pick the same port file and collide.
+        randPortSuffix = Random.randstring(Random.RandomDevice(), 10)
         args2 = "-z=julia.$(randPortSuffix)"
 
         stdoutfile = "stdout-$(randPortSuffix).log"

--- a/src/omcSession.jl
+++ b/src/omcSession.jl
@@ -110,7 +110,11 @@ mutable struct ZMQSession
                 # ompath=joinpath(omhome,"bin")
                 ## create a omc process with default OPENMODELICAHOME set in environment variable
                 withenv("OPENMODELICAHOME" => omhome) do
-                    omcprocess = open(pipeline(`$ompath $args1 $args2`))
+                    # Redirect to files like every other branch. Without a
+                    # redirect omc's output goes to a pipe nobody reads, and a
+                    # chatty run -- `-d=` debug flags, say -- fills the pipe
+                    # buffer and blocks omc forever.
+                    omcprocess = open(pipeline(`$ompath $args1 $args2`, stdout=stdoutfile, stderr=stderrfile))
                 end
             end
             portfile = join(["openmodelica.port.julia.", randPortSuffix])
@@ -151,6 +155,11 @@ mutable struct ZMQSession
         filedata = read(fullpath, String)
         context = ZMQ.Context()
         socket = ZMQ.Socket(context, REQ)
+        # ZMQ lingers indefinitely by default, so closing a socket whose peer is
+        # gone blocks forever -- if omc dies with a request outstanding, Julia
+        # then hangs on exit in the socket finalizer. Nothing is gained by
+        # waiting to flush a request omc will never read.
+        socket.linger = 0
         ZMQ.connect(socket, filedata)
 
         zmqSession = new(context, socket, omcprocess)

--- a/src/sendExpression.jl
+++ b/src/sendExpression.jl
@@ -27,6 +27,54 @@ CONDITIONS OF OSMC-PL.
 =#
 
 """
+How long to block in a single `recv` before looking up to check on omc, in
+milliseconds. This is not a timeout on the call: a slow API call simply goes
+around the loop again. It only bounds how long we can sit in an unreturnable
+`recv` after omc is already gone.
+"""
+const RECEIVE_POLL_INTERVAL_MS = 500
+
+"""
+    receiveMessage(omc, expr, timeout)
+
+Wait for omc's reply to `expr`.
+
+`ZMQ.recv` on its own blocks forever, so an omc that dies mid-call -- or never
+answers -- hangs the caller with no way out but killing Julia. Poll instead,
+and between polls check that omc is still alive.
+
+`timeout` in seconds puts a hard cap on the wait; `nothing` waits as long as
+omc is running, which is what a long `simulate` needs.
+"""
+function receiveMessage(omc::OMCSession, expr::AbstractString, timeout::Union{Real, Nothing})
+    socket = omc.zmqSession.socket
+    previousTimeout = socket.rcvtimeo
+    socket.rcvtimeo = RECEIVE_POLL_INTERVAL_MS
+    deadline = isnothing(timeout) ? nothing : time() + timeout
+    try
+        while true
+            try
+                return ZMQ.Sockets.recv(socket)
+            catch err
+                err isa ZMQ.TimeoutError || rethrow()
+                if !process_running(omc.zmqSession.omcprocess)
+                    error("omc exited while waiting for a reply to `$(expr)`. " *
+                          "The session is dead; create a new OMCSession. " *
+                          "See the omc stdout/stderr logs for why it stopped.")
+                end
+                if !isnothing(deadline) && time() >= deadline
+                    error("No reply from omc for `$(expr)` after $(timeout) s. " *
+                          "omc is still running, so it may just be slow -- pass a " *
+                          "larger `timeout`, or `nothing` to wait indefinitely.")
+                end
+            end
+        end
+    finally
+        socket.rcvtimeo = previousTimeout
+    end
+end
+
+"""
     sendExpression(omc, expr; parsed=true)
 
 Send API call to OpenModelica ZMQ server.
@@ -71,7 +119,7 @@ omc = OMJulia.OMCSession()
 OMJulia.sendExpression(omc, "getVersion()")
 ```
 """
-function sendExpression(omc::OMCSession, expr::String; parsed=true)
+function sendExpression(omc::OMCSession, expr::String; parsed=true, timeout::Union{Real, Nothing}=nothing)
     if !process_running(omc.zmqSession.omcprocess)
         return error("Process Exited, No connection with OMC. Create a new instance of OMCSession")
     end
@@ -79,7 +127,7 @@ function sendExpression(omc::OMCSession, expr::String; parsed=true)
     @debug "sending expression: $(expr)"
     ZMQ.Sockets.send(omc.zmqSession.socket, expr)
     @debug "Receiving message from ZMQ socket"
-    message = ZMQ.Sockets.recv(omc.zmqSession.socket)
+    message = receiveMessage(omc, expr, timeout)
     @debug "Recieved message"
     if parsed
         return Parser.parseOM(unsafe_string(message))

--- a/test/omcTest.jl
+++ b/test/omcTest.jl
@@ -97,3 +97,38 @@ import OMJulia
         end
     end
 end
+
+# `ZMQ.recv` blocks forever, so an omc that dies mid-call used to hang the
+# caller with no way out but killing Julia. Poll instead and check omc is still
+# alive between polls. See https://github.com/OpenModelica/OMJulia.jl/issues/12
+@testset "Dead omc is reported, not waited on" begin
+    omc = OMJulia.OMCSession()
+    try
+        @test OMJulia.sendExpression(omc, "1+1") == 2
+
+        # A call slower than the poll interval must not be cut short.
+        @test OMJulia.sendExpression(omc, "getVersion()", timeout = 60) isa AbstractString
+
+        # Kill omc while it is working on a request.
+        @async begin
+            sleep(0.15)
+            kill(omc.zmqSession.omcprocess, Base.SIGKILL)
+        end
+        @test_throws ErrorException OMJulia.sendExpression(omc, "loadModel(Modelica)")
+    finally
+        try; OMJulia.quit(omc); catch; end
+    end
+end
+
+@testset "Explicit timeout gives up" begin
+    omc = OMJulia.OMCSession()
+    try
+        # omc is alive and simply has not answered yet, so this exercises the
+        # deadline rather than the liveness check.
+        @test_throws ErrorException OMJulia.sendExpression(omc, "loadModel(Modelica)",
+                                                           timeout = 0.001)
+    finally
+        # The socket is left mid-exchange, so kill rather than a polite quit.
+        try; kill(omc.zmqSession.omcprocess, Base.SIGKILL); catch; end
+    end
+end


### PR DESCRIPTION
Closes #12.

@JKRT asked in 2019 for exactly this:

> we have ZMQ communication but we do not have any timeout or polling to make
> the decision to throw a communication error and terminate [...] This
> permanently blocks OMJulia and you need to quit the application.

## The fix

`sendExpression` called `ZMQ.recv`, which blocks forever. Poll on a short
receive timeout instead, and check between polls that omc is still running.

A slow call is unaffected — it simply goes round the loop again — so a long
`simulate` still waits as long as it needs. But a dead omc now raises within one
poll interval. Measured against omc 1.28-dev: killing omc mid-request hung
indefinitely before (I gave up at 45 s), and now raises after 0.5 s with

```
omc exited while waiting for a reply to `loadModel(Modelica)`. The session is
dead; create a new OMCSession. See the omc stdout/stderr logs for why it stopped.
```

`sendExpression` also gains an optional `timeout` in seconds for callers who
want a hard cap. The default stays `nothing`, so existing code keeps today's
behaviour for as long as omc is alive.

## Two more hangs, found while testing this

**ZMQ lingers forever by default.** Closing a socket whose peer is gone blocks
indefinitely, so with a request outstanding to a dead omc, Julia hung *at exit*
inside the socket finalizer — after the tests had already reported success. That
took a while to find, because the tests pass and the process still never
returns. `linger = 0`; there is nothing to gain by waiting to flush a request
omc will never read.

**On Windows omc is spawned with no stdout redirect**, unlike every other branch
in `ZMQSession`. Its output goes to a pipe nobody reads, so a chatty run fills
the pipe buffer and blocks omc. Now redirected to the same log files the other
branches use.

## What this does not close

I said earlier this might close the whole ZMQ cluster. Having looked, it does
not, and I would rather say so than have the issues closed wrongly:

- **#59** (hang on long debug output) — omc stays alive, so the liveness check
  never fires. The Windows redirect above is a plausible cause but I cannot
  reproduce it here to confirm.
- **#39** (freeze on the first command) — a race while connecting, with omc
  alive.
- **#66** (`ZMQ.StateError` under the VS Code debugger) — different mechanism.

All three become escapable rather than fatal, since `timeout` now gives callers
a way out that does not involve killing Julia. That is not the same as fixed.

## Why the first CI run timed out

All four jobs went silent and were killed at the 30 minute limit. The cause was
not the new tests as such, but something they made likely.

The port file omc and OMJulia rendezvous on is named with
`Random.randstring(10)` off the global RNG. `@testset` saves and reseeds that
RNG identically for every testset, so the draw is not random across testsets:

```julia
@testset "a" begin println(randstring(10)) end   # 41mPGMhQUu
@testset "b" begin println(randstring(10)) end   # 41mPGMhQUu
@testset "c" begin println(randstring(10)) end   # 41mPGMhQUu
```

Every session created first inside a testset picks the same port file and
collides with the others. The CI log shows it plainly — the same suffix,
`828aWWD5LX`, repeated across five sessions, then twenty minutes of silence.
Adding two testsets that each open a session was enough to tip it over.

Fixed by drawing from `RandomDevice`, which the reseeding does not touch. This
is a latent bug in `ZMQSession` rather than anything to do with timeouts, but it
has to be fixed here or the tests in this PR cannot run.

Full `runtests.jl` now completes locally: 77 passing, 2 errors, both the
`convertMo2FMU` failure on machines without `zip` on PATH, which also fails on
master.

## Saying why the FMU tests fail

Those two errors used to report themselves as

```
MethodError: no method matching joinpath(::Nothing)
```

because `convertMo2FMU` and `convertFmu2Mo` reported failure with
`return println(...)` — printing the reason and returning `nothing`, which the
caller then used as a path. The real cause went to stdout, separately from the
exception and, in a test run, far from the failure it explained.

They raise now, with the omc error string in the message:

```
Failed to build FMU for ModSeborgCSTRorg:
Error: Error building simulator. Build log: rm -f "ModSeborgCSTRorg.fmu"
&& cd "266.fmutmp" && zip -r "../ModSeborgCSTRorg.fmu" *
```

which names the missing `zip`. omc shells out to `zip` to package the FMU, so
this is a real environment requirement rather than a bug — it just never said
so. Same treatment for the `fileNamePrefix` length check and for a missing FMU
path in `convertFmu2Mo`.

Note this converts a silent `nothing` into a thrown error, so it is a behaviour
change for any caller testing the result for `nothing` instead of checking
`isfile`. Worth doing before 1.0 rather than after.

## Tests

Four new assertions covering a normal call, a call slower than the poll
interval, omc killed mid-request, and an explicit timeout expiring. Full
`omcTest.jl` passes (11 existing + 4 new), parser suite 37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Version

Bumped to **0.4.0**, not 0.3.4. Below 1.0 the minor is the breaking position,
and this release breaks two things:

- `convertMo2FMU` / `convertFmu2Mo` raise where they returned `nothing`, which
  breaks a caller testing for `nothing` rather than checking `isfile`.
- Splitting `simflags` on whitespace (#133, already on master) changes the
  meaning of a single flag containing a space — `simflags="-r=/path/with
  space/out.mat"` now arrives as two arguments. Narrow, and that form never
  worked reliably, but a behaviour change all the same.

The earlier 0.3.4 bump was made when the content was only the lexer work and
nothing was breaking.