### PR TITLE
Wait for the omc port file against the clock

### DIFF
--- a/src/error.jl
+++ b/src/error.jl
@@ -60,5 +60,7 @@ struct TimeoutError <: Exception
 end
 function Base.showerror(io::IO, e::TimeoutError)
   println(io, "TimeoutError")
-  print(e.msg)
+  # `print(e.msg)` went to stdout, so the message landed somewhere else in the
+  # output and the reported error was a bare "TimeoutError" with no detail.
+  print(io, e.msg)
 end

--- a/src/omcSession.jl
+++ b/src/omcSession.jl
@@ -60,6 +60,65 @@ mutable struct Linearization
 end
 
 """
+How long to wait for omc to write its ZMQ port file, in seconds.
+
+A healthy omc writes the file in well under a second and the wait ends the
+moment it appears, so this only bounds the pathological case. It is generous
+on purpose: the first omc start on a cold machine pays for paging the omc
+libraries off disk past the virus scanner, which has taken several seconds on
+a Windows CI runner.
+"""
+const PORT_FILE_TIMEOUT_S = 30
+
+"""
+    waitForPortFile(fullpath, omcprocess; timeout=PORT_FILE_TIMEOUT_S)
+
+Wait for `omcprocess` to write its ZMQ port file at `fullpath`.
+
+Return `true` as soon as the file exists, `false` if `timeout` seconds pass
+without it or if omc exits without ever writing it.
+
+Wait against the clock rather than counting `sleep`s. `sleep` rounds up to the
+OS timer granularity -- of the order of 15 ms on Windows against 1 ms on Linux
+-- so a fixed iteration count buys a different amount of time on every
+platform, and the amount it buys on Windows was not enough.
+"""
+function waitForPortFile(fullpath::AbstractString, omcprocess::Base.Process;
+                         timeout::Real=PORT_FILE_TIMEOUT_S)
+    deadline = time() + timeout
+    while true
+        isfile(fullpath) && return true
+        # omc is gone and is never going to write the file. Look once more, in
+        # case it wrote the file and exited between the two checks, then give
+        # up rather than sit out the rest of the deadline.
+        process_exited(omcprocess) && return isfile(fullpath)
+        time() >= deadline && return false
+        sleep(0.01)
+    end
+end
+
+"""
+    omcStartupLog(stdoutfile, stderrfile)
+
+omc's redirected output, formatted for an error message. Empty when omc said
+nothing or the logs cannot be read -- a missing log must not turn the error
+being reported into an unrelated IO error.
+"""
+function omcStartupLog(stdoutfile::AbstractString, stderrfile::AbstractString)
+    buffer = IOBuffer()
+    for (name, file) in (("stdout", stdoutfile), ("stderr", stderrfile))
+        contents = try
+            isfile(file) ? read(file, String) : ""
+        catch
+            ""
+        end
+        isempty(strip(contents)) && continue
+        print(buffer, "\nomc $(name):\n", contents)
+    end
+    return String(take!(buffer))
+end
+
+"""
     ZMQSession <: Any
 
 ZeroMQ session running interactive omc process.
@@ -142,20 +201,25 @@ mutable struct ZMQSession
         end
         fullpath = joinpath(tempdir(), portfile)
         @info("Path to zmq file=\"$fullpath\"")
-        ## Try to find better approach if possible, as sleep does not work properly across different platform
-        tries = 0
-        while tries < 100 && !isfile(fullpath)
-            sleep(0.02)
-            tries += 1
-        end
+        started = waitForPortFile(fullpath, omcprocess)
         # Catch omc error
         if process_exited(omcprocess) && omcprocess.exitcode != 0
             throw(OMCError(omcprocess.cmd, stdoutfile, stderrfile))
         end
-        rm.([stdoutfile, stderrfile], force=true)
-        if tries >= 100
-            throw(TimeoutError("ZMQ server port file \"$fullpath\" not created yet."))
+        if !started
+            # Read the logs before deleting them. Without them the error says
+            # only that a file is missing, which is no help in working out why.
+            # Kill omc too: no ZMQSession exists yet to carry the finalizer that
+            # would reap it, so it would be left running for the rest of the
+            # session, competing for the CPU the next start needs.
+            details = omcStartupLog(stdoutfile, stderrfile)
+            kill(omcprocess)
+            rm.([stdoutfile, stderrfile], force=true)
+            throw(TimeoutError("omc did not create the ZMQ server port file " *
+                               "\"$(fullpath)\" within $(PORT_FILE_TIMEOUT_S) s." *
+                               details))
         end
+        rm.([stdoutfile, stderrfile], force=true)
         filedata = read(fullpath, String)
         context = ZMQ.Context()
         socket = ZMQ.Socket(context, REQ)

--- a/test/portFileTest.jl
+++ b/test/portFileTest.jl
@@ -1,0 +1,143 @@
+#=
+This file is part of OpenModelica.
+Copyright (c) 1998-2023, Open Source Modelica Consortium (OSMC),
+c/o Linköpings universitet, Department of Computer and Information Science,
+SE-58183 Linköping, Sweden.
+
+All rights reserved.
+
+THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ACCORDING TO RECIPIENTS CHOICE.
+
+The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+Public License (OSMC-PL) are obtained from OSMC, either from the above
+address, from the URLs: http://www.openmodelica.org or
+http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+distribution. GNU version 3 is obtained from:
+http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+http://www.opensource.org/licenses/BSD-3-Clause.
+
+This program is distributed WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+CONDITIONS OF OSMC-PL.
+=#
+
+using Test
+import OMJulia
+
+# A stand-in for omc: a process that never writes a port file. Julia itself, so
+# these tests need no OpenModelica installation.
+function dummyProcess(expression::AbstractString)
+    cmd = `$(Base.julia_cmd()) --startup-file=no -e $expression`
+    return open(pipeline(cmd, stdout=devnull, stderr=devnull))
+end
+
+# The wait used to be 100 iterations of `sleep(0.02)`, which is a different
+# amount of time on every platform and was too little for a cold omc start on
+# Windows. See https://github.com/OpenModelica/OMJulia.jl/issues/137
+@testset "Waiting for the omc port file" begin
+    @testset "Returns at once when the file is already there" begin
+        mktempdir() do dir
+            portfile = joinpath(dir, "openmodelica.port.julia.here")
+            touch(portfile)
+            process = dummyProcess("sleep(60)")
+            try
+                started = time()
+                found = OMJulia.waitForPortFile(portfile, process, timeout = 60)
+                elapsed = time() - started
+                @test found
+                @test elapsed < 1
+            finally
+                kill(process)
+            end
+        end
+    end
+
+    @testset "Picks the file up while waiting" begin
+        mktempdir() do dir
+            portfile = joinpath(dir, "openmodelica.port.julia.late")
+            process = dummyProcess("sleep(60)")
+            try
+                @async begin
+                    sleep(0.3)
+                    touch(portfile)
+                end
+                @test OMJulia.waitForPortFile(portfile, process, timeout = 60)
+            finally
+                kill(process)
+            end
+        end
+    end
+
+    @testset "Gives up at the deadline" begin
+        mktempdir() do dir
+            portfile = joinpath(dir, "openmodelica.port.julia.never")
+            process = dummyProcess("sleep(60)")
+            try
+                started = time()
+                found = OMJulia.waitForPortFile(portfile, process, timeout = 0.5)
+                elapsed = time() - started
+                @test !found
+                # The deadline is honoured, and honoured in wall-clock seconds
+                # rather than in whatever a fixed number of `sleep`s costs here.
+                @test elapsed >= 0.5
+                @test elapsed < 10
+            finally
+                kill(process)
+            end
+        end
+    end
+
+    @testset "Stops early when omc exits without writing it" begin
+        mktempdir() do dir
+            portfile = joinpath(dir, "openmodelica.port.julia.dead")
+            process = dummyProcess("exit(0)")
+            try
+                started = time()
+                found = OMJulia.waitForPortFile(portfile, process, timeout = 60)
+                elapsed = time() - started
+                @test !found
+                # Nothing to wait for once omc is gone, so this must not sit out
+                # the deadline.
+                @test elapsed < 30
+            finally
+                kill(process)
+            end
+        end
+    end
+end
+
+@testset "A timeout says why" begin
+    @testset "omc's output is folded into the message" begin
+        mktempdir() do dir
+            stdoutfile = joinpath(dir, "stdout.log")
+            stderrfile = joinpath(dir, "stderr.log")
+            write(stdoutfile, "omc said something\n")
+            write(stderrfile, "omc complained\n")
+
+            details = OMJulia.omcStartupLog(stdoutfile, stderrfile)
+            @test occursin("omc said something", details)
+            @test occursin("omc complained", details)
+        end
+    end
+
+    @testset "Missing logs do not mask the timeout" begin
+        mktempdir() do dir
+            @test OMJulia.omcStartupLog(joinpath(dir, "gone"),
+                                        joinpath(dir, "also-gone")) == ""
+        end
+    end
+
+    @testset "The message reaches the error output" begin
+        # `showerror` printed the message to stdout instead of `io`, so the
+        # reported error was a bare "TimeoutError" with the detail stranded
+        # elsewhere in the log.
+        buffer = IOBuffer()
+        showerror(buffer, OMJulia.TimeoutError("the port file never showed up"))
+        @test occursin("the port file never showed up", String(take!(buffer)))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,7 @@ using Test
 
 @testset "OMJulia" begin
     @safetestset "Parsing" begin include("parserTest.jl") end
+    @safetestset "Port file" begin include("portFileTest.jl") end
     @safetestset "OMCSession" begin include("omcTest.jl") end
     @safetestset "ModelicaSystem" begin include("modelicaSystemTest.jl") end
     @safetestset "API" begin include("apiTest.jl") end


### PR DESCRIPTION
Fixes #137.

The first `OMCSession()` of a run intermittently times out on `windows-latest` before omc has written its ZMQ port file. Every later session in the same job starts fine — the cold-start signature, where the first `omc.exe` launch pays for paging the omc libraries off disk past the virus scanner.

## What was wrong

```julia
tries = 0
while tries < 100 && !isfile(fullpath)
    sleep(0.02)
    tries += 1
end
...
rm.([stdoutfile, stderrfile], force=true)
if tries >= 100
    throw(TimeoutError("ZMQ server port file \"$fullpath\" not created yet."))
end
```

**The budget was a loop count, not a deadline.** `sleep` rounds up to the OS timer granularity, of the order of 15 ms on Windows against 1 ms on Linux, so 100 iterations are worth about 2 s on Linux and about 6 s on Windows. [Run 34333928137](https://github.com/OpenModelica/OMJulia.jl/actions/runs/34333928137) logs `Path to zmq file=...` at 09:44:06.83 and the timeout at 09:44:12.66 — 5.83 s, 58 ms an iteration. A number that means something different on each platform cannot be tuned.

**Off-by-one.** The loop exited on `tries == 100` without re-checking `isfile`, and the error was raised on the counter rather than on the file still being absent, so a port file that appeared during the final sleep was thrown away.

**The timeout destroyed its own evidence.** `rm.([stdoutfile, stderrfile])` ran one line before the check, so the error named a path and nothing else. `omcprocess` was never killed either — the finalizer is registered on `ZMQSession`, which is never constructed on this path — so every timeout orphaned a live `omc.exe` that went on competing for the CPU the next start needs.

## What this changes

`waitForPortFile` waits against the wall clock with a 30 s cap, returns the moment the file appears, and gives up early if omc exits rather than sitting out the deadline. The cap costs nothing in the healthy case, where the file shows up in well under a second.

The absence of the file, not the state of a counter, is what raises the error. On that path omc is killed and its stdout/stderr are folded into the message before the logs are removed.

`TimeoutError`'s `showerror` did `print(e.msg)` instead of `print(io, e.msg)`, so the message went to stdout and the reported error was a bare `TimeoutError` with the detail stranded elsewhere in the log — visible in the run above. Fixed here too, since the point of the change is that a timeout explains itself.

## Tests

`test/portFileTest.jl` covers the wait with a dummy process, so it needs no OpenModelica installation: file already present, file appearing mid-wait, the deadline being honoured in wall-clock seconds, and giving up early when the process exits. Plus the log folding, a missing log not masking the timeout, and `showerror` reaching `io` — the last of which fails without the `error.jl` change.

Not run locally: this machine has neither `julia` nor `omc`. CI is the first real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
