### PR TITLE
Bump the license headers to 2026

### DIFF
--- a/bin/check_lexer.jl
+++ b/bin/check_lexer.jl
@@ -1,3 +1,31 @@
+#=
+This file is part of OpenModelica.
+Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+c/o Linköpings universitet, Department of Computer and Information Science,
+SE-58183 Linköping, Sweden.
+
+All rights reserved.
+
+THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ACCORDING TO RECIPIENTS CHOICE.
+
+The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+Public License (OSMC-PL) are obtained from OSMC, either from the above
+address, from the URLs: http://www.openmodelica.org or
+http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+distribution. GNU version 3 is obtained from:
+http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+http://www.opensource.org/licenses/BSD-3-Clause.
+
+This program is distributed WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+CONDITIONS OF OSMC-PL.
+=#
+
 # Check that src/lexer.jl still matches the grammar in bin/generate_lexer.jl.
 #
 #     julia --project=bin bin/check_lexer.jl

--- a/bin/generate_lexer.jl
+++ b/bin/generate_lexer.jl
@@ -1,3 +1,31 @@
+#=
+This file is part of OpenModelica.
+Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+c/o Linköpings universitet, Department of Computer and Information Science,
+SE-58183 Linköping, Sweden.
+
+All rights reserved.
+
+THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ACCORDING TO RECIPIENTS CHOICE.
+
+The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+Public License (OSMC-PL) are obtained from OSMC, either from the above
+address, from the URLs: http://www.openmodelica.org or
+http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+distribution. GNU version 3 is obtained from:
+http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+http://www.opensource.org/licenses/BSD-3-Clause.
+
+This program is distributed WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+CONDITIONS OF OSMC-PL.
+=#
+
 # Generate a Lexer for OpenModelica output (Values.Value)
 # =====================================================================
 #

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,3 +1,31 @@
+#=
+This file is part of OpenModelica.
+Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+c/o Linköpings universitet, Department of Computer and Information Science,
+SE-58183 Linköping, Sweden.
+
+All rights reserved.
+
+THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ACCORDING TO RECIPIENTS CHOICE.
+
+The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+Public License (OSMC-PL) are obtained from OSMC, either from the above
+address, from the URLs: http://www.openmodelica.org or
+http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+distribution. GNU version 3 is obtained from:
+http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+http://www.opensource.org/licenses/BSD-3-Clause.
+
+This program is distributed WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+CONDITIONS OF OSMC-PL.
+=#
+
 using Documenter, OMJulia
 
 ENV["JULIA_DEBUG"]="Documenter"

--- a/regression-tests/regressionTests.jl
+++ b/regression-tests/regressionTests.jl
@@ -1,6 +1,6 @@
 #=
 This file is part of OpenModelica.
-Copyright (c) 1998-2023, Open Source Modelica Consortium (OSMC),
+Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
 c/o Linköpings universitet, Department of Computer and Information Science,
 SE-58183 Linköping, Sweden.
 

--- a/regression-tests/runSingleTest.jl
+++ b/regression-tests/runSingleTest.jl
@@ -1,6 +1,6 @@
 #=
 This file is part of OpenModelica.
-Copyright (c) 1998-2023, Open Source Modelica Consortium (OSMC),
+Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
 c/o Linköpings universitet, Department of Computer and Information Science,
 SE-58183 Linköping, Sweden.
 

--- a/src/OMJulia.jl
+++ b/src/OMJulia.jl
@@ -1,6 +1,6 @@
 #=
 This file is part of OpenModelica.
-Copyright (c) 1998-2023, Open Source Modelica Consortium (OSMC),
+Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
 c/o Linköpings universitet, Department of Computer and Information Science,
 SE-58183 Linköping, Sweden.
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,6 +1,6 @@
 #=
 This file is part of OpenModelica.
-Copyright (c) 1998-2023, Open Source Modelica Consortium (OSMC),
+Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
 c/o Linköpings universitet, Department of Computer and Information Science,
 SE-58183 Linköping, Sweden.
 

--- a/src/error.jl
+++ b/src/error.jl
@@ -1,6 +1,6 @@
 #=
 This file is part of OpenModelica.
-Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
 c/o Linköpings universitet, Department of Computer and Information Science,
 SE-58183 Linköping, Sweden.
 

--- a/src/modelicaSystem.jl
+++ b/src/modelicaSystem.jl
@@ -1,6 +1,6 @@
 #=
 This file is part of OpenModelica.
-Copyright (c) 1998-2023, Open Source Modelica Consortium (OSMC),
+Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
 c/o Linköpings universitet, Department of Computer and Information Science,
 SE-58183 Linköping, Sweden.
 

--- a/src/omcSession.jl
+++ b/src/omcSession.jl
@@ -1,6 +1,6 @@
 #=
 This file is part of OpenModelica.
-Copyright (c) 1998-2023, Open Source Modelica Consortium (OSMC),
+Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
 c/o Linköpings universitet, Department of Computer and Information Science,
 SE-58183 Linköping, Sweden.
 

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -1,3 +1,31 @@
+#=
+This file is part of OpenModelica.
+Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+c/o Linköpings universitet, Department of Computer and Information Science,
+SE-58183 Linköping, Sweden.
+
+All rights reserved.
+
+THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ACCORDING TO RECIPIENTS CHOICE.
+
+The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+Public License (OSMC-PL) are obtained from OSMC, either from the above
+address, from the URLs: http://www.openmodelica.org or
+http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+distribution. GNU version 3 is obtained from:
+http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+http://www.opensource.org/licenses/BSD-3-Clause.
+
+This program is distributed WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+CONDITIONS OF OSMC-PL.
+=#
+
 module Parser
 
 # Proposed for Julia 1.5.x

--- a/src/sendExpression.jl
+++ b/src/sendExpression.jl
@@ -1,6 +1,6 @@
 #=
 This file is part of OpenModelica.
-Copyright (c) 1998-2023, Open Source Modelica Consortium (OSMC),
+Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
 c/o Linköpings universitet, Department of Computer and Information Science,
 SE-58183 Linköping, Sweden.
 

--- a/test/apiTest.jl
+++ b/test/apiTest.jl
@@ -1,6 +1,6 @@
 #=
 This file is part of OpenModelica.
-Copyright (c) 1998-2023, Open Source Modelica Consortium (OSMC),
+Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
 c/o Linköpings universitet, Department of Computer and Information Science,
 SE-58183 Linköping, Sweden.
 

--- a/test/modelicaSystemTest.jl
+++ b/test/modelicaSystemTest.jl
@@ -1,6 +1,6 @@
 #=
 This file is part of OpenModelica.
-Copyright (c) 1998-2023, Open Source Modelica Consortium (OSMC),
+Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
 c/o Linköpings universitet, Department of Computer and Information Science,
 SE-58183 Linköping, Sweden.
 

--- a/test/omcTest.jl
+++ b/test/omcTest.jl
@@ -1,6 +1,6 @@
 #=
 This file is part of OpenModelica.
-Copyright (c) 1998-2023, Open Source Modelica Consortium (OSMC),
+Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
 c/o Linköpings universitet, Department of Computer and Information Science,
 SE-58183 Linköping, Sweden.
 

--- a/test/parserTest.jl
+++ b/test/parserTest.jl
@@ -1,6 +1,6 @@
 #=
 This file is part of OpenModelica.
-Copyright (c) 1998-2023, Open Source Modelica Consortium (OSMC),
+Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
 c/o Linköpings universitet, Department of Computer and Information Science,
 SE-58183 Linköping, Sweden.
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 #=
 This file is part of OpenModelica.
-Copyright (c) 1998-2023, Open Source Modelica Consortium (OSMC),
+Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
 c/o Linköpings universitet, Department of Computer and Information Science,
 SE-58183 Linköping, Sweden.
 

--- a/test/testFMIExport.jl
+++ b/test/testFMIExport.jl
@@ -1,6 +1,6 @@
 #=
 This file is part of OpenModelica.
-Copyright (c) 1998-2023, Open Source Modelica Consortium (OSMC),
+Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
 c/o Linköpings universitet, Department of Computer and Information Science,
 SE-58183 Linköping, Sweden.
 


### PR DESCRIPTION
Text-only. No code changes.

Thirteen files still read `Copyright (c) 1998-2023`, and `src/error.jl` read `1998-CurrentYear`, a placeholder that was never substituted for anything. All fourteen now read `1998-2026`.

Four hand-written sources carried no header at all and get the same block: `src/parser.jl`, `docs/make.jl`, `bin/check_lexer.jl`, `bin/generate_lexer.jl`.

`src/lexer.jl` is deliberately left alone. It is generated by `bin/generate_lexer.jl` and says so at the top, so a header there belongs in the generator's output template rather than in the file — one added by hand would be undone by the next regeneration. Happy to add it to the template instead if you would rather have it. `LICENSE.md` and `docs/README.md` are not sources and carry no header by design.

18 files, 1 line each on the fourteen, a 27-line block on the four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
