### PR TITLE
CI: fix the top-level scope bug that breaks the Nightly MSL sweep

### DIFF
--- a/regression-tests/areaCoverageReport.jl
+++ b/regression-tests/areaCoverageReport.jl
@@ -44,10 +44,9 @@ area = ARGS[1]
 version = length(ARGS) >= 2 ? ARGS[2] : "4.1.0"
 
 omc = OMJulia.OMCSession()
-local models
-try
+models = try
   OMJulia.sendExpression(omc, "loadModel(Modelica, {\"$(version)\"})")
-  models = exampleModels(omc, area)
+  exampleModels(omc, area)
 finally
   OMJulia.quit(omc)
 end

--- a/regression-tests/listMslAreas.jl
+++ b/regression-tests/listMslAreas.jl
@@ -39,10 +39,9 @@ include("enumerateExamples.jl")
 version = length(ARGS) >= 1 ? ARGS[1] : "4.1.0"
 
 omc = OMJulia.OMCSession()
-local areas
-try
+areas = try
   OMJulia.sendExpression(omc, "loadModel(Modelica, {\"$(version)\"})")
-  areas = mslAreasWithExamples(omc)
+  mslAreasWithExamples(omc)
 finally
   OMJulia.quit(omc)
 end


### PR DESCRIPTION
The first Nightly run failed before it got to the MSL sweep:
https://github.com/OpenModelica/OMJulia.jl/actions/runs/34591075298

```
ERROR: LoadError: UndefVarError: `areas` not defined in `Main`
  @ regression-tests/listMslAreas.jl:50
```

`local areas` at the top level of a script does not reserve a name for the
code after it. `try` opens its own scope, the assignment inside lands there,
and by the line after `end` it is gone. Minimal repro:

```julia
local x
try
  x = 1
finally
end
println(x)   # UndefVarError
```

`msl-areas` is what the `msl-coverage` matrix shards over, so its failure
skipped the sweep and the docs page entirely. `areaCoverageReport.jl` carried
the same `local models` and would have failed the same way once it ran.
`runSingleTest.jl`'s `local resultFile` is inside a function, where `local`
means what it looks like, and is untouched.

The fix is to let the `try` block return the value.

Verified against a local omc v1.28.0-dev-573:

```
$ julia --project=regression-tests/. regression-tests/listMslAreas.jl
areas=["Blocks","Clocked","ComplexBlocks","Electrical","Fluid","Magnetic","Math","Mechanics","Media","StateGraph","Thermal","Utilities"]
```

Not covered here: the `nightly (1.12, windows-latest, nightly)` job in the same
run died in `setup-openmodelica@v1.0` with `Error: spawn EBUSY` while starting
the freshly downloaded installer. That is a Windows runner flake, not OMJulia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
